### PR TITLE
Removing the dynamic profile info file from the running the test.

### DIFF
--- a/test/runtests.py
+++ b/test/runtests.py
@@ -767,14 +767,12 @@ def main():
     # test variants
     variants = [x for x in [
         TestVariant('interpreted', extra_flags + [
-                '-maxInterpretCount:1', '-maxSimpleJitRunCount:1', '-bgjit-',
-                '-dynamicprofilecache:profile.dpl.${id}'
+                '-maxInterpretCount:1', '-maxSimpleJitRunCount:1', '-bgjit-'
             ], [
                 'require_disable_jit'
             ]),
         TestVariant('dynapogo', extra_flags + [
-                '-forceNative', '-off:simpleJit', '-bgJitDelay:0',
-                '-dynamicprofileinput:profile.dpl.${id}'
+                '-forceNative', '-off:simpleJit', '-bgJitDelay:0'
             ], [
                 'require_disable_jit'
             ]),


### PR DESCRIPTION
These tests run on Linux and there is no support for the dynamic profile input. Removed those flag as they were slowing the tests.
