### PR TITLE
[WIP] Fix liveness tracking for aux slot pointer sym

### DIFF
--- a/test/Optimizer/aux_slot_6311.js
+++ b/test/Optimizer/aux_slot_6311.js
@@ -1,0 +1,13 @@
+var count = 0;
+var myEval = eval;
+
+function foo() {
+  count += 1;
+  myEval("var v" + count);
+}
+
+for (i = 0, v0 = 0; i < 10; i += count, v0 += 1) {
+  foo(v0);
+}
+
+print('PASSED');

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1628,4 +1628,10 @@
       <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>aux_slot_6311.js</files>
+      <compile-flags>-forcejitloopbody</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
@pleath This change appears to resolve #6311, but I'd like your input.

The problem appears to be that we are not correctly tracking the liveness of the aux slot pointer sym. If there is a property opnd for the object that is not type-specialized for some reason, we aren't clearing the aux slot pointer sym from the live list in the forward pass.

What are your thoughts?