### PR TITLE
Single target testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,31 +10,32 @@ if(NOT CHAKRACORE_BUILD_SH)
     option(INTL_ICU "Enable Intl" ON)
     option(EMBED_ICU "Build ICU within ChakraCore build" OFF)
     set(ICU_INCLUDE_PATH "" CACHE STRING "libicu iclude path")
+else(NOT CHAKRACORE_BUILD_SH)
+
+    # Keep CMake from caching static/shared library
+    # option. Otherwise, CMake fails to update cached
+    # references
+
+    # todo: create a sub cmake file to take care of _SH uncaching...
+    if(SHARED_LIBRARY_SH)
+    unset(SHARED_LIBRARY_SH CACHE)
+    unset(STATIC_LIBRARY_SH CACHE)
+        unset(STATIC_LIBRARY CACHE)
+        set(SHARED_LIBRARY 1)
+    endif()
+
+    if(STATIC_LIBRARY_SH)
+        unset(SHARED_LIBRARY_SH CACHE)
+        unset(STATIC_LIBRARY_SH CACHE)
+        unset(SHARED_LIBRARY CACHE)
+        set(STATIC_LIBRARY 1)
+    endif()
+
+    if(LIBS_ONLY_BUILD_SH)
+        unset(LIBS_ONLY_BUILD_SH CACHE)
+        set(CC_LIBS_ONLY_BUILD 1)
+    endif()
 endif(NOT CHAKRACORE_BUILD_SH)
-
-# Keep CMake from caching static/shared library
-# option. Otherwise, CMake fails to update cached
-# references
-
-# todo: create a sub cmake file to take care of _SH uncaching...
-if(SHARED_LIBRARY_SH)
-    unset(SHARED_LIBRARY_SH CACHE)
-    unset(STATIC_LIBRARY_SH CACHE)
-    unset(STATIC_LIBRARY CACHE)
-    set(SHARED_LIBRARY 1)
-endif()
-
-if(STATIC_LIBRARY_SH)
-    unset(SHARED_LIBRARY_SH CACHE)
-    unset(STATIC_LIBRARY_SH CACHE)
-    unset(SHARED_LIBRARY CACHE)
-    set(STATIC_LIBRARY 1)
-endif()
-
-if(LIBS_ONLY_BUILD_SH)
-    unset(LIBS_ONLY_BUILD_SH CACHE)
-    set(CC_LIBS_ONLY_BUILD 1)
-endif()
 
 if(CC_USES_SYSTEM_ARCH_SH OR NOT CHAKRACORE_BUILD_SH)
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,13 @@ jobs:
       matrix:
         debug:
           build_type: 'Debug'
+          test_target: 'check'
         release_with_debug:
           build_type: 'RelWithDebInfo'
+          test_target: 'check'
+        release:
+          build_type: 'Release'
+          test_target: 'all'
 
     steps:
     - script: sudo apt-get install -y ninja-build clang libicu-dev
@@ -31,5 +36,7 @@ jobs:
 
     - script: |
         cd build
-        ninja check
+        ninja $TARGET
       displayName: 'Build and test'
+      env:
+        TARGET: $(test_target)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,24 +3,47 @@ trigger:
 - release/*
 
 jobs:
-  - job: Linux
+  - job: CMake
     timeoutInMinutes: 0
-    pool:
-      vmImage: 'ubuntu-latest'
     strategy:
       matrix:
-        debug:
+        Linux.Debug:
+          image_name: 'ubuntu-latest'
+          deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'Debug'
           test_target: 'check'
-        release_with_debug:
+        Linux.ReleaseWithDebug:
+          image_name: 'ubuntu-latest'
+          deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'RelWithDebInfo'
           test_target: 'check'
-        release:
+        Linux.Release:
+          image_name: 'ubuntu-latest'
+          deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
+          build_type: 'Release'
+          test_target: 'all'
+      matrix:
+        OSX.Debug:
+          image_name: 'macOS-latest'
+          deps: 'brew install ninja icu4c'
+          build_type: 'Debug'
+          test_target: 'check'
+        OSX.ReleaseWithDebug:
+          image_name: 'macOS-latest'
+          deps: 'brew install ninja icu4c'
+          build_type: 'RelWithDebInfo'
+          test_target: 'check'
+        OSX.Release:
+          image_name: 'macOS-latest'
+          deps: 'brew install ninja icu4c'
           build_type: 'Release'
           test_target: 'all'
 
+    pool:
+      vmImage: $(image_name)
+      
     steps:
-    - script: sudo apt-get install -y ninja-build clang libicu-dev
+    - script: $(deps)
       displayName: 'Install dependencies'
   
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,7 @@ jobs:
 
     - script: |
         cd build
+        echo Library flag $(LIBTYPE)
         cmake -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $(LIBTYPE) -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
       displayName: CMake
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,6 @@ jobs:
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'Release'
           test_target: 'all'
-      matrix:
         OSX.Debug:
           image_name: 'macOS-latest'
           deps: 'brew install ninja icu4c'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,8 +57,7 @@ jobs:
 
     - script: |
         cd build
-        echo Library flag $(LIBTYPE)
-        cmake -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $(LIBTYPE) -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
+        cmake -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $LIBTYPE -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
       displayName: CMake
       env:
         BUILD_TYPE: $(build_type)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,5 @@ jobs:
 
     - script: |
         cd build
-        ninja
         ninja check
       displayName: 'Build and test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ trigger:
 
 jobs:
   - job: CMake
-    timeoutInMinutes: 0
+    timeoutInMinutes: 120
     strategy:
       matrix:
         Linux.Debug:
@@ -12,31 +12,37 @@ jobs:
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'Debug'
           test_target: 'check'
+          libtype_flag: ''
         Linux.ReleaseWithDebug:
           image_name: 'ubuntu-latest'
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'RelWithDebInfo'
           test_target: 'check'
+          libtype_flag: ''
         Linux.Release:
           image_name: 'ubuntu-latest'
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'Release'
           test_target: 'all'
+          libtype_flag: ''
         OSX.Debug:
           image_name: 'macOS-latest'
           deps: 'brew install ninja icu4c'
           build_type: 'Debug'
           test_target: 'check'
+          libtype_flag: '-DSTATIC_LIBRARY=ON'
         OSX.ReleaseWithDebug:
           image_name: 'macOS-latest'
           deps: 'brew install ninja icu4c'
           build_type: 'RelWithDebInfo'
           test_target: 'check'
+          libtype_flag: ''
         OSX.Release:
           image_name: 'macOS-latest'
           deps: 'brew install ninja icu4c'
           build_type: 'Release'
           test_target: 'all'
+          libtype_flag: ''
 
     pool:
       vmImage: $(image_name)
@@ -51,10 +57,11 @@ jobs:
 
     - script: |
         cd build
-        cmake -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
+        cmake -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $(LIBTYPE) -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
       displayName: CMake
       env:
         BUILD_TYPE: $(build_type)
+        LIBTYPE: $(libtype_flag)
 
     - script: |
         cd build

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,10 @@ add_custom_target(check
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/runtests.py ${TEST_BUILD_TYPE} ${TEST_EXCLUDE} --binary ${CMAKE_BINARY_DIR}/ch --logfile ${CMAKE_BINARY_DIR}/check.log
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     USES_TERMINAL
-    DEPENDS ch ChakraCore
+    DEPENDS ch
     )
+
+if (NOT STATIC_LIBRARY)
+    add_dependencies(check ChakraCore)
+endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,6 @@ add_custom_target(check
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/runtests.py ${TEST_BUILD_TYPE} ${TEST_EXCLUDE} --binary ${CMAKE_BINARY_DIR}/ch --logfile ${CMAKE_BINARY_DIR}/check.log
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     USES_TERMINAL
-    DEPENDS ch
+    DEPENDS ch ChakraCore
     )
 


### PR DESCRIPTION
Enable building and testing via a single target (check) - require chakracore
library to be built before the test run.

For #6547 