### PR TITLE
Linux/macOS CI remove excess logging, improve remaining output + other tidyup

### DIFF
--- a/test/Basics/rlexe.xml
+++ b/test/Basics/rlexe.xml
@@ -312,7 +312,7 @@
       <files>VerifyParserState.js</files>
       <baseline>VerifyParserState.baseline</baseline>
       <compile-flags>-UseParserStateCache -ParserStateCache -Force:DeferParse -Trace:CreateParserState</compile-flags>
-      <tags>exclude_test,exclude_jshost</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -320,21 +320,21 @@
       <files>VerifySkipNestedDeferred.js</files>
       <baseline>VerifySkipNestedDeferred.baseline</baseline>
       <compile-flags>-UseParserStateCache -ParserStateCache -Force:DeferParse -Trace:SkipNestedDeferred</compile-flags>
-      <tags>exclude_test,exclude_jshost,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
     <default>
       <files>bug_os17542375.js</files>
       <compile-flags>-UseParserStateCache -ParserStateCache -Force:DeferParse -pageheap:2</compile-flags>
-      <tags>exclude_test,exclude_jshost</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
     <default>
       <files>bug_os16855035.js</files>
       <compile-flags>-UseParserStateCache -ParserStateCache -Force:DeferParse -Force:Redeferral -CollectGarbage</compile-flags>
-      <tags>exclude_test,exclude_jshost</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -492,14 +492,12 @@
   <test>
     <default>
       <files>bug_OS17530048.js</files>
-      <tags>exclude_jshost</tags>
       <compile-flags>-force:deferparse -parserstatecache -useparserstatecache</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>skipping_nested_deferred_incorrect_function_id.js</files>
-      <tags>exclude_jshost</tags>
       <compile-flags>-force:deferparse -parserstatecache -useparserstatecache</compile-flags>
     </default>
   </test>
@@ -533,7 +531,6 @@
   <test>
     <default>
       <files>deferredStubBugs.js</files>
-      <tags>exclude_jshost</tags>
       <compile-flags>-force:deferparse -parserstatecache -useparserstatecache</compile-flags>
     </default>
   </test>
@@ -541,21 +538,18 @@
     <default>
       <files>SuperAccessInGlobalLambda.js</files>
       <baseline>SuperAccessInGlobalLambda.baseline</baseline>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
     <default>
       <files>bug_5572_wscript_loadscript_loadmodule.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
     <default>
       <files>function_id_destructured_reparse.js</files>
       <compile-flags>-useparserstatecache -parserstatecache -force:deferparse</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NO_ICU)
 endif()
 
 add_custom_target(check
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/runtests.py ${TEST_BUILD_TYPE} ${TEST_EXCLUDE} --binary ${CMAKE_BINARY_DIR}/ch --logfile ${CMAKE_BINARY_DIR}/check.log
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/runtests.py ${TEST_BUILD_TYPE} ${TEST_EXCLUDE} --binary ${CMAKE_BINARY_DIR}/ch
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     USES_TERMINAL
     DEPENDS ch

--- a/test/Error/rlexe.xml
+++ b/test/Error/rlexe.xml
@@ -75,7 +75,6 @@
       <files>sourceInfo_01.js</files>
       <baseline>sourceInfo_01.baseline</baseline>
       <compile-flags>-ExtendedErrorStackForTestHost</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
@@ -90,7 +89,6 @@
       <files>sourceInfo_11.js</files>
       <baseline>sourceInfo_11.baseline</baseline>
       <compile-flags>-ExtendedErrorStackForTestHost</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
@@ -105,7 +103,6 @@
       <files>sourceInfo_13.js</files>
       <baseline>sourceInfo_13.baseline</baseline>
       <compile-flags>-ExtendedErrorStackForTestHost</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
@@ -113,7 +110,6 @@
       <files>sourceInfo_20.js</files>
       <baseline>sourceInfo_20.baseline</baseline>
       <compile-flags>-ExtendedErrorStackForTestHost</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -262,7 +262,6 @@
     <default>
       <files>toStringAll.js</files>
       <baseline>toStringAll.baseline</baseline>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
@@ -270,7 +269,6 @@
       <files>toStringAll.js</files>
       <baseline>toStringAll.baseline</baseline>
       <compile-flags>-force:DeferParse</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
@@ -278,7 +276,6 @@
       <files>toStringAll.js</files>
       <baseline>toStringAll.baseline</baseline>
       <compile-flags>-force:DeferParse -ForceSerialized</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
@@ -286,7 +283,6 @@
       <files>toStringAll.js</files>
       <baseline>toStringAll.baseline</baseline>
       <compile-flags>-force:DeferParse -UseParserStateCache -ParserStateCache</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
@@ -517,7 +513,6 @@
     <default>
       <files>bug_os17698041.js</files>
       <compile-flags>-off:deferparse -force:redeferral -collectgarbage -parserstatecache -useparserstatecache</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
 </regress-exe>

--- a/test/Miscellaneous/rlexe.xml
+++ b/test/Miscellaneous/rlexe.xml
@@ -6,7 +6,7 @@
       <files>../../lib/Runtime/Library/JsBuiltIn/JsBuiltIn.js</files>
       <baseline>../../lib/Runtime/Library/JsBuiltIn/JsBuiltIn.js.bc.32b.h</baseline>
       <compile-flags>-GenerateLibraryByteCodeHeader -JsBuiltIn -LdChakraLib</compile-flags>
-      <tags>exclude_jshost,exclude_dynapogo,exclude_x64,exclude_disable_jit,exclude_lite,exclude_forceserialized</tags>
+      <tags>exclude_dynapogo,exclude_x64,exclude_disable_jit,exclude_lite,exclude_forceserialized</tags>
       <eol-normalization />
     </default>
   </test>
@@ -15,7 +15,7 @@
       <files>../../lib/Runtime/Library/JsBuiltIn/JsBuiltIn.js</files>
       <baseline>../../lib/Runtime/Library/JsBuiltIn/JsBuiltIn.js.bc.64b.h</baseline>
       <compile-flags>-GenerateLibraryByteCodeHeader -JsBuiltIn -LdChakraLib</compile-flags>
-      <tags>exclude_jshost,exclude_dynapogo,exclude_x86,exclude_disable_jit,exclude_lite,exclude_forceserialized</tags>
+      <tags>exclude_dynapogo,exclude_x86,exclude_disable_jit,exclude_lite,exclude_forceserialized</tags>
       <eol-normalization />
     </default>
   </test>
@@ -24,7 +24,7 @@
       <files>../../lib/Runtime/Library/JsBuiltIn/JsBuiltIn.js</files>
       <baseline>../../lib/Runtime/Library/JsBuiltIn/JsBuiltIn.js.nojit.bc.32b.h</baseline>
       <compile-flags>-GenerateLibraryByteCodeHeader -JsBuiltIn -LdChakraLib</compile-flags>
-      <tags>exclude_jshost,exclude_x64,require_disable_jit,exclude_forceserialized</tags>
+      <tags>exclude_x64,require_disable_jit,exclude_forceserialized</tags>
       <eol-normalization />
     </default>
   </test>
@@ -33,7 +33,7 @@
       <files>../../lib/Runtime/Library/JsBuiltIn/JsBuiltIn.js</files>
       <baseline>../../lib/Runtime/Library/JsBuiltIn/JsBuiltIn.js.nojit.bc.64b.h</baseline>
       <compile-flags>-GenerateLibraryByteCodeHeader -JsBuiltIn -LdChakraLib</compile-flags>
-      <tags>exclude_jshost,exclude_x86,require_disable_jit,exclude_forceserialized</tags>
+      <tags>exclude_x86,require_disable_jit,exclude_forceserialized</tags>
       <eol-normalization />
     </default>
   </test>
@@ -42,7 +42,7 @@
       <files>../../lib/Runtime/Library/InJavascript/Intl.js</files>
       <baseline>../../lib/Runtime/Library/InJavascript/Intl.js.bc.32b.h</baseline>
       <compile-flags>-GenerateLibraryByteCodeHeader -Intl</compile-flags>
-      <tags>exclude_jshost,exclude_dynapogo,exclude_x64,exclude_disable_jit,exclude_lite,exclude_forceserialized</tags>
+      <tags>exclude_dynapogo,exclude_x64,exclude_disable_jit,exclude_lite,exclude_forceserialized</tags>
       <eol-normalization />
     </default>
   </test>
@@ -51,7 +51,7 @@
       <files>../../lib/Runtime/Library/InJavascript/Intl.js</files>
       <baseline>../../lib/Runtime/Library/InJavascript/Intl.js.bc.64b.h</baseline>
       <compile-flags>-GenerateLibraryByteCodeHeader -Intl</compile-flags>
-      <tags>exclude_jshost,exclude_dynapogo,exclude_x86,exclude_disable_jit,exclude_lite,exclude_forceserialized</tags>
+      <tags>exclude_dynapogo,exclude_x86,exclude_disable_jit,exclude_lite,exclude_forceserialized</tags>
       <eol-normalization />
     </default>
   </test>
@@ -60,7 +60,7 @@
       <files>../../lib/Runtime/Library/InJavascript/Intl.js</files>
       <baseline>../../lib/Runtime/Library/InJavascript/Intl.js.nojit.bc.32b.h</baseline>
       <compile-flags>-GenerateLibraryByteCodeHeader -Intl</compile-flags>
-      <tags>exclude_jshost,exclude_x64,require_disable_jit,exclude_lite,exclude_forceserialized</tags>
+      <tags>exclude_x64,require_disable_jit,exclude_lite,exclude_forceserialized</tags>
       <eol-normalization />
     </default>
   </test>
@@ -69,7 +69,7 @@
       <files>../../lib/Runtime/Library/InJavascript/Intl.js</files>
       <baseline>../../lib/Runtime/Library/InJavascript/Intl.js.nojit.bc.64b.h</baseline>
       <compile-flags>-GenerateLibraryByteCodeHeader -Intl</compile-flags>
-      <tags>exclude_jshost,exclude_x86,require_disable_jit,exclude_lite,exclude_forceserialized</tags>
+      <tags>exclude_x86,require_disable_jit,exclude_lite,exclude_forceserialized</tags>
       <eol-normalization />
     </default>
   </test>

--- a/test/Scanner/rlexe.xml
+++ b/test/Scanner/rlexe.xml
@@ -16,7 +16,6 @@
     <default>
       <files>Hashbang.js</files>
       <compile-flags>-args summary -endargs -ESHashbang</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
 </regress-exe>

--- a/test/TTBasic/rlexe.xml
+++ b/test/TTBasic/rlexe.xml
@@ -5,7 +5,7 @@
       <files>accessor.js</files>
       <compile-flags>-TTRecord=accessorTest -TTSnapInterval=0</compile-flags>
       <baseline>accessorRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -13,7 +13,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=accessorTest -TTDStartEvent=2</compile-flags>
       <baseline>accessorReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -21,7 +21,7 @@
       <files>arguments.js</files>
       <compile-flags>-TTRecord=argumentsTest -TTSnapInterval=0</compile-flags>
       <baseline>argumentsRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -29,7 +29,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=argumentsTest -TTDStartEvent=2</compile-flags>
       <baseline>argumentsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -37,7 +37,7 @@
       <files>array.js</files>
       <compile-flags>-TTRecord=arrayTest -TTSnapInterval=0</compile-flags>
       <baseline>arrayRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -45,7 +45,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=arrayTest -TTDStartEvent=2</compile-flags>
       <baseline>arrayReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -53,7 +53,7 @@
       <files>bind.js</files>
       <compile-flags>-TTRecord=bindTest -TTSnapInterval=0</compile-flags>
       <baseline>bindRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -61,7 +61,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=bindTest -TTDStartEvent=2</compile-flags>
       <baseline>bindReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -69,7 +69,7 @@
       <files>boolean.js</files>
       <compile-flags>-TTRecord=booleanTest -TTSnapInterval=0</compile-flags>
       <baseline>booleanRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -77,7 +77,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=booleanTest -TTDStartEvent=2</compile-flags>
       <baseline>booleanReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -85,7 +85,7 @@
       <files>boundFunction.js</files>
       <compile-flags>-TTRecord=boundFunctionTest -TTSnapInterval=0</compile-flags>
       <baseline>boundFunctionRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -93,7 +93,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=boundFunctionTest -TTDStartEvent=2</compile-flags>
       <baseline>boundFunctionReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -101,7 +101,7 @@
       <files>boxedObject.js</files>
       <compile-flags>-TTRecord=boxedObjectTest -TTSnapInterval=0</compile-flags>
       <baseline>boxedObjectRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -109,7 +109,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=boxedObjectTest -TTDStartEvent=2</compile-flags>
       <baseline>boxedObjectReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -117,7 +117,7 @@
       <files>crossSiteMain.js</files>
       <compile-flags>-TTRecord=crossSiteTest -TTSnapInterval=0</compile-flags>
       <baseline>crossSiteRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -125,7 +125,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=crossSiteTest</compile-flags>
       <baseline>crossSiteReplay1.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -133,7 +133,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=crossSiteTest -TTDStartEvent=2</compile-flags>
       <baseline>crossSiteReplay2.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -141,7 +141,7 @@
       <files>constructor.js</files>
       <compile-flags>-TTRecord=constructorTest -TTSnapInterval=0</compile-flags>
       <baseline>constructorRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -149,7 +149,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=constructorTest -TTDStartEvent=2</compile-flags>
       <baseline>constructorReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -157,7 +157,7 @@
       <files>dateBasic.js</files>
       <compile-flags>-TTRecord=dateBasicTest -TTSnapInterval=0</compile-flags>
       <baseline>dateBasicRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -165,7 +165,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=dateBasicTest</compile-flags>
       <baseline>dateBasicReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -173,7 +173,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=dateBasicTest -TTDStartEvent=2</compile-flags>
       <baseline>dateBasicReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -181,7 +181,7 @@
       <files>deleteArray.js</files>
       <compile-flags>-TTRecord=deleteArrayTest -TTSnapInterval=0</compile-flags>
       <baseline>deleteArrayRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -189,7 +189,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=deleteArrayTest -TTDStartEvent=2</compile-flags>
       <baseline>deleteArrayReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -197,7 +197,7 @@
       <files>es5Array.js</files>
       <compile-flags>-TTRecord=es5ArrayTest -TTSnapInterval=0</compile-flags>
       <baseline>es5ArrayRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -205,7 +205,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=es5ArrayTest -TTDStartEvent=2</compile-flags>
       <baseline>es5ArrayReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -213,7 +213,7 @@
       <files>es5Arguments.js</files>
       <compile-flags>-TTRecord=es5ArgumentsTest -TTSnapInterval=0</compile-flags>
       <baseline>es5ArgumentsRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -221,7 +221,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=es5ArgumentsTest -TTDStartEvent=2</compile-flags>
       <baseline>es5ArgumentsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -229,7 +229,7 @@
       <files>eval.js</files>
       <compile-flags>-TTRecord=evalTest -TTSnapInterval=0</compile-flags>
       <baseline>evalRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -237,7 +237,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=evalTest -TTDStartEvent=2</compile-flags>
       <baseline>evalReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -245,7 +245,7 @@
       <files>extensible.js</files>
       <compile-flags>-TTRecord=extensibleTest -TTSnapInterval=0</compile-flags>
       <baseline>extensibleRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -253,7 +253,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=extensibleTest -TTDStartEvent=2</compile-flags>
       <baseline>extensibleReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -261,7 +261,7 @@
       <files>forInShadowing.js</files>
       <compile-flags>-TTRecord=forInShadowingTest -TTSnapInterval=0</compile-flags>
       <baseline>forInShadowingRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -269,7 +269,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=forInShadowingTest -TTDStartEvent=2</compile-flags>
       <baseline>forInShadowingReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -277,7 +277,7 @@
       <files>freeze.js</files>
       <compile-flags>-TTRecord=freezeTest -TTSnapInterval=0</compile-flags>
       <baseline>freezeRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -285,7 +285,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=freezeTest -TTDStartEvent=2</compile-flags>
       <baseline>freezeReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -293,7 +293,7 @@
       <files>function.js</files>
       <compile-flags>-TTRecord=functionTest -TTSnapInterval=0</compile-flags>
       <baseline>functionRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -301,7 +301,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=functionTest -TTDStartEvent=2</compile-flags>
       <baseline>functionReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -309,7 +309,7 @@
       <files>largeAuxArray.js</files>
       <compile-flags>-TTRecord=largeAuxArrayTest -TTSnapInterval=0</compile-flags>
       <baseline>largeAuxArrayRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -317,7 +317,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=largeAuxArrayTest -TTDStartEvent=2</compile-flags>
       <baseline>largeAuxArrayReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -325,7 +325,7 @@
       <files>loadReEntrant.js</files>
       <compile-flags>-TTRecord=loadReEntrantTest -TTSnapInterval=0</compile-flags>
       <baseline>loadReEntrantRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -333,7 +333,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=loadReEntrantTest</compile-flags>
       <baseline>loadReEntrantReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -341,7 +341,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=loadReEntrantTest -TTDStartEvent=2</compile-flags>
       <baseline>loadReEntrantReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -349,7 +349,7 @@
       <files>map.js</files>
       <compile-flags>-TTRecord=mapTest -TTSnapInterval=0</compile-flags>
       <baseline>mapRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -357,7 +357,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=mapTest -TTDStartEvent=2</compile-flags>
       <baseline>mapReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -365,7 +365,7 @@
       <files>missingArray.js</files>
       <compile-flags>-TTRecord=missingArrayTest -TTSnapInterval=0</compile-flags>
       <baseline>missingArrayRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -373,7 +373,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=missingArrayTest -TTDStartEvent=2</compile-flags>
       <baseline>missingArrayReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -381,7 +381,7 @@
       <files>nativeArray.js</files>
       <compile-flags>-TTRecord=nativeArrayTest -TTSnapInterval=0</compile-flags>
       <baseline>nativeArrayRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -389,7 +389,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=nativeArrayTest -TTDStartEvent=2</compile-flags>
       <baseline>nativeArrayReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -397,7 +397,7 @@
       <files>newFromArgs.js</files>
       <compile-flags>-TTRecord=newFromArgsTest -TTSnapInterval=0</compile-flags>
       <baseline>newFromArgsRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -405,7 +405,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=newFromArgsTest -TTDStartEvent=2</compile-flags>
       <baseline>newFromArgsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -413,7 +413,7 @@
       <files>newFunction.js</files>
       <compile-flags>-TTRecord=newFunctionTest -TTSnapInterval=0</compile-flags>
       <baseline>newFunctionRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -421,7 +421,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=newFunctionTest -TTDStartEvent=2</compile-flags>
       <baseline>newFunctionReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -429,7 +429,7 @@
       <files>number.js</files>
       <compile-flags>-TTRecord=numberTest -TTSnapInterval=0</compile-flags>
       <baseline>numberRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -437,7 +437,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=numberTest -TTDStartEvent=2</compile-flags>
       <baseline>numberReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -445,7 +445,7 @@
       <files>numericPropertyIsEnumerable.js</files>
       <compile-flags>-TTRecord=numericPropertyIsEnumerableTest -TTSnapInterval=0</compile-flags>
       <baseline>numericPropertyIsEnumerableRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -453,7 +453,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=numericPropertyIsEnumerableTest -TTDStartEvent=2</compile-flags>
       <baseline>numericPropertyIsEnumerableReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -461,7 +461,7 @@
       <files>object.js</files>
       <compile-flags>-TTRecord=objectTest -TTSnapInterval=0</compile-flags>
       <baseline>objectRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -469,7 +469,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=objectTest -TTDStartEvent=2</compile-flags>
       <baseline>objectReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -477,7 +477,7 @@
       <files>popArrayImplicitCall.js</files>
       <compile-flags>-TTRecord=popArrayImplicitCallTest -TTSnapInterval=0</compile-flags>
       <baseline>popArrayImplicitCallRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -485,7 +485,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=popArrayImplicitCallTest -TTDStartEvent=2</compile-flags>
       <baseline>popArrayImplicitCallReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -493,7 +493,7 @@
       <files>promise.js</files>
       <compile-flags>-TTRecord=promiseTest -TTSnapInterval=0</compile-flags>
       <baseline>promiseRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -501,7 +501,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promiseTest</compile-flags>
       <baseline>promiseReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -509,7 +509,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promiseTest -TTDStartEvent=2</compile-flags>
       <baseline>promiseReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -517,7 +517,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promiseTest -TTDStartEvent=4</compile-flags>
       <baseline>promiseReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -525,7 +525,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promiseTest -TTDStartEvent=6</compile-flags>
       <baseline>promiseReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -533,7 +533,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promiseTest -TTDStartEvent=7</compile-flags>
       <baseline>promiseReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -541,7 +541,7 @@
       <files>promise_MultipleThenCalls.js</files>
       <compile-flags>-TTRecord=promise_MultipleThenCallsTest -TTSnapInterval=0</compile-flags>
       <baseline>promise_MultipleThenCallsRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -549,7 +549,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promise_MultipleThenCallsTest -TTDStartEvent=1</compile-flags>
       <baseline>promise_MultipleThenCallsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -557,7 +557,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promise_MultipleThenCallsTest -TTDStartEvent=2</compile-flags>
       <baseline>promise_MultipleThenCallsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -565,7 +565,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promise_MultipleThenCallsTest -TTDStartEvent=3</compile-flags>
       <baseline>promise_MultipleThenCallsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -573,7 +573,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promise_MultipleThenCallsTest -TTDStartEvent=4</compile-flags>
       <baseline>promise_MultipleThenCallsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -581,7 +581,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promise_MultipleThenCallsTest -TTDStartEvent=5</compile-flags>
       <baseline>promise_MultipleThenCallsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -589,7 +589,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promise_MultipleThenCallsTest -TTDStartEvent=6</compile-flags>
       <baseline>promise_MultipleThenCallsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -597,7 +597,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=promise_MultipleThenCallsTest -TTDStartEvent=7</compile-flags>
       <baseline>promise_MultipleThenCallsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -605,7 +605,7 @@
       <files>proxy.js</files>
       <compile-flags>-TTRecord=proxyTest -TTSnapInterval=0</compile-flags>
       <baseline>proxyRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -613,7 +613,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=proxyTest -TTDStartEvent=2</compile-flags>
       <baseline>proxyReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -621,7 +621,7 @@
       <files>regex.js</files>
       <compile-flags>-TTRecord=regexTest -TTSnapInterval=0</compile-flags>
       <baseline>regexRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -629,7 +629,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=regexTest -TTDStartEvent=2</compile-flags>
       <baseline>regexReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -637,7 +637,7 @@
       <files>seal.js</files>
       <compile-flags>-TTRecord=sealTest -TTSnapInterval=0</compile-flags>
       <baseline>sealRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -645,7 +645,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=sealTest -TTDStartEvent=2</compile-flags>
       <baseline>sealReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -653,7 +653,7 @@
       <files>scopedAccessors.js</files>
       <compile-flags>-TTRecord=scopedAccessorsTest -TTSnapInterval=0</compile-flags>
       <baseline>scopedAccessorsRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -661,7 +661,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=scopedAccessorsTest -TTDStartEvent=2</compile-flags>
       <baseline>scopedAccessorsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -669,7 +669,7 @@
       <files>scopeFunction.js</files>
       <compile-flags>-TTRecord=scopeFunctionTest -TTSnapInterval=0</compile-flags>
       <baseline>scopeFunctionRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -677,7 +677,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=scopeFunctionTest -TTDStartEvent=2</compile-flags>
       <baseline>scopeFunctionReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -685,7 +685,7 @@
       <files>set.js</files>
       <compile-flags>-TTRecord=setTest -TTSnapInterval=0</compile-flags>
       <baseline>setRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -693,7 +693,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=setTest -TTDStartEvent=2</compile-flags>
       <baseline>setReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -701,7 +701,7 @@
       <files>shadowPrototype.js</files>
       <compile-flags>-TTRecord=shadowPrototypeTest -TTSnapInterval=0</compile-flags>
       <baseline>shadowPrototypeRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -709,7 +709,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=shadowPrototypeTest -TTDStartEvent=2</compile-flags>
       <baseline>shadowPrototypeReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -717,7 +717,7 @@
       <files>sparseArray.js</files>
       <compile-flags>-TTRecord=sparseArrayTest -TTSnapInterval=0</compile-flags>
       <baseline>sparseArrayRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -725,7 +725,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=sparseArrayTest -TTDStartEvent=2</compile-flags>
       <baseline>sparseArrayReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -733,7 +733,7 @@
       <files>string.js</files>
       <compile-flags>-TTRecord=stringTest -TTSnapInterval=0</compile-flags>
       <baseline>stringRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -741,7 +741,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=stringTest -TTDStartEvent=2</compile-flags>
       <baseline>stringReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -749,7 +749,7 @@
       <files>symbol.js</files>
       <compile-flags>-TTRecord=symbolTest -TTSnapInterval=0</compile-flags>
       <baseline>symbolRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -757,7 +757,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=symbolTest</compile-flags>
       <baseline>symbolReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -765,7 +765,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=symbolTest -TTDStartEvent=2</compile-flags>
       <baseline>symbolReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -773,7 +773,7 @@
       <files>typeConversions.js</files>
       <compile-flags>-TTRecord=typeConversionTest -TTSnapInterval=0</compile-flags>
       <baseline>typeConversionsRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -781,7 +781,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=typeConversionTest -TTDStartEvent=2</compile-flags>
       <baseline>typeConversionsReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -789,7 +789,7 @@
       <files>typedArray.js</files>
       <compile-flags>-TTRecord=typedArrayTest -TTSnapInterval=0</compile-flags>
       <baseline>typedArrayRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -797,7 +797,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=typedArrayTest -TTDStartEvent=2</compile-flags>
       <baseline>typedArrayReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -805,7 +805,7 @@
       <files>typePromotion.js</files>
       <compile-flags>-TTRecord=typePromotionTest -TTSnapInterval=0</compile-flags>
       <baseline>typePromotionRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -813,7 +813,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=typePromotionTest -TTDStartEvent=2</compile-flags>
       <baseline>typePromotionReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -821,7 +821,7 @@
       <files>generatorBasic.js</files>
       <compile-flags>-TTRecord=generatorBasicTest -TTSnapInterval=0</compile-flags>
       <baseline>generatorBasicRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -829,7 +829,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorBasicTest -TTDStartEvent=1</compile-flags>
       <baseline>generatorBasicReplay_1.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -837,7 +837,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorBasicTest -TTDStartEvent=2</compile-flags>
       <baseline>generatorBasicReplay_2.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -845,7 +845,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorBasicTest -TTDStartEvent=3</compile-flags>
       <baseline>generatorBasicReplay_3.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -853,7 +853,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorBasicTest -TTDStartEvent=4</compile-flags>
       <baseline>generatorBasicReplay_4.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -861,7 +861,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorBasicTest -TTDStartEvent=5</compile-flags>
       <baseline>generatorBasicReplay_5.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -869,7 +869,7 @@
       <files>generatorReturnYieldResult.js</files>
       <compile-flags>-TTRecord=generatorReturnYieldResult -TTSnapInterval=0</compile-flags>
       <baseline>generatorReturnYieldResultRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -877,7 +877,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorReturnYieldResult -TTDStartEvent=1</compile-flags>
       <baseline>generatorReturnYieldResultReplay_1.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -885,7 +885,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorReturnYieldResult -TTDStartEvent=2</compile-flags>
       <baseline>generatorReturnYieldResultReplay_2.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -893,7 +893,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorReturnYieldResult -TTDStartEvent=3</compile-flags>
       <baseline>generatorReturnYieldResultReplay_3.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -901,7 +901,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorReturnYieldResult -TTDStartEvent=4</compile-flags>
       <baseline>generatorReturnYieldResultReplay_4.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -909,7 +909,7 @@
       <files>generatorIntParam.js</files>
       <compile-flags>-TTRecord=generatorIntParamTest -TTSnapInterval=0</compile-flags>
       <baseline>generatorIntParamRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -917,7 +917,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorIntParamTest -TTDStartEvent=4</compile-flags>
       <baseline>generatorIntParamReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -925,7 +925,7 @@
       <files>generatorObjectParam.js</files>
       <compile-flags>-TTRecord=generatorObjectParamTest -TTSnapInterval=0</compile-flags>
       <baseline>generatorObjectParamRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -933,7 +933,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorObjectParamTest -TTDStartEvent=4</compile-flags>
       <baseline>generatorObjectParamReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -941,7 +941,7 @@
       <files>generatorClassMethod.js</files>
       <compile-flags>-TTRecord=generatorClassMethodTest -TTSnapInterval=0</compile-flags>
       <baseline>generatorClassMethodRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -949,7 +949,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorClassMethodTest -TTDStartEvent=4</compile-flags>
       <baseline>generatorClassMethodReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -957,7 +957,7 @@
       <files>generatorNested.js</files>
       <compile-flags>-TTRecord=generatorNestedTest -TTSnapInterval=0</compile-flags>
       <baseline>generatorNestedRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -965,7 +965,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorNestedTest -TTDStartEvent=4</compile-flags>
       <baseline>generatorNestedReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -973,7 +973,7 @@
       <files>generatorRestoreCompletedGenerator.js</files>
       <compile-flags>-TTRecord=generatorRestoreCompletedGeneratorTest -TTSnapInterval=0</compile-flags>
       <baseline>generatorRestoreCompletedGeneratorRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -981,7 +981,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorRestoreCompletedGeneratorTest -TTDStartEvent=6</compile-flags>
       <baseline>generatorRestoreCompletedGeneratorReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -989,7 +989,7 @@
       <files>generatorWriteLogDuringGeneratorExecution.js</files>
       <compile-flags>-TTRecord=generatorWriteLogDuringGeneratorExecutionTest -TTSnapInterval=0</compile-flags>
       <baseline>generatorWriteLogDuringGeneratorExecutionRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -997,7 +997,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorWriteLogDuringGeneratorExecutionTest -TTDStartEvent=1</compile-flags>
       <baseline>generatorWriteLogDuringGeneratorExecutionReplay_1.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1005,7 +1005,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorWriteLogDuringGeneratorExecutionTest -TTDStartEvent=2</compile-flags>
       <baseline>generatorWriteLogDuringGeneratorExecutionReplay_2.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1013,7 +1013,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorWriteLogDuringGeneratorExecutionTest -TTDStartEvent=3</compile-flags>
       <baseline>generatorWriteLogDuringGeneratorExecutionReplay_3.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1021,7 +1021,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorWriteLogDuringGeneratorExecutionTest -TTDStartEvent=4</compile-flags>
       <baseline>generatorWriteLogDuringGeneratorExecutionReplay_4.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1029,7 +1029,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorWriteLogDuringGeneratorExecutionTest -TTDStartEvent=5</compile-flags>
       <baseline>generatorWriteLogDuringGeneratorExecutionReplay_5.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1037,7 +1037,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=generatorWriteLogDuringGeneratorExecutionTest -TTDStartEvent=6</compile-flags>
       <baseline>generatorWriteLogDuringGeneratorExecutionReplay_6.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1045,7 +1045,7 @@
       <files>asyncAwaitBasic.js</files>
       <compile-flags>-TTRecord=asyncAwaitBasicTest -TTSnapInterval=0</compile-flags>
       <baseline>asyncAwaitBasicRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1053,7 +1053,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=asyncAwaitBasicTest -TTDStartEvent=1</compile-flags>
       <baseline>asyncAwaitBasicReplay_1.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
     <test>
@@ -1061,7 +1061,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=asyncAwaitBasicTest -TTDStartEvent=2</compile-flags>
       <baseline>asyncAwaitBasicReplay_2.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
     <test>
@@ -1069,7 +1069,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=asyncAwaitBasicTest -TTDStartEvent=3</compile-flags>
       <baseline>asyncAwaitBasicReplay_3.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
     <test>
@@ -1077,7 +1077,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=asyncAwaitBasicTest -TTDStartEvent=4</compile-flags>
       <baseline>asyncAwaitBasicReplay_4.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
     <test>
@@ -1085,7 +1085,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=asyncAwaitBasicTest -TTDStartEvent=5</compile-flags>
       <baseline>asyncAwaitBasicReplay_5.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1093,7 +1093,7 @@
       <files>asyncAwait2.js</files>
       <compile-flags>-TTRecord=asyncAwait2Test -TTSnapInterval=0</compile-flags>
       <baseline>asyncAwait2Record.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1101,7 +1101,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=asyncAwait2Test -TTDStartEvent=1</compile-flags>
       <baseline>asyncAwait2Replay_1.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
     <test>
@@ -1109,7 +1109,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=asyncAwait2Test -TTDStartEvent=5</compile-flags>
       <baseline>asyncAwait2Replay_2.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1117,7 +1117,7 @@
       <files>asyncAwait3.js</files>
       <compile-flags>-TTRecord=asyncAwait3Test -TTSnapInterval=0</compile-flags>
       <baseline>asyncAwait3Record.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -1125,7 +1125,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=asyncAwait3Test -TTDStartEvent=1</compile-flags>
       <baseline>asyncAwait3Replay_1.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
     <test>
@@ -1133,7 +1133,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=asyncAwait3Test -TTDStartEvent=5</compile-flags>
       <baseline>asyncAwait3Replay_2.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
 </regress-exe>

--- a/test/TTExecuteBasic/rlexe.xml
+++ b/test/TTExecuteBasic/rlexe.xml
@@ -5,7 +5,7 @@
       <files>callbackSingle.js</files>
       <compile-flags>-TTRecord=callbackSingleTest -TTSnapInterval=0</compile-flags>
       <baseline>callbackSingleRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -13,7 +13,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=callbackSingleTest</compile-flags>
       <baseline>callbackSingleReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -21,7 +21,7 @@
       <files>callbackSpread.js</files>
       <compile-flags>-TTRecord=callbackSpreadTest -TTSnapInterval=0</compile-flags>
       <baseline>callbackSpreadRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -29,7 +29,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=callbackSpreadTest</compile-flags>
       <baseline>callbackSpreadReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -37,7 +37,7 @@
       <files>callbackSequence.js</files>
       <compile-flags>-TTRecord=callbackSequenceTest -TTSnapInterval=0</compile-flags>
       <baseline>callbackSequenceRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -45,7 +45,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=callbackSequenceTest</compile-flags>
       <baseline>callbackSequenceReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -53,7 +53,7 @@
       <files>callbackClear.js</files>
       <compile-flags>-TTRecord=callbackClearTest -TTSnapInterval=0</compile-flags>
       <baseline>callbackClearRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -61,7 +61,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=callbackClearTest</compile-flags>
       <baseline>callbackClearReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -69,7 +69,7 @@
       <files>enumerable.js</files>
       <compile-flags>-TTRecord=enumerableTest -TTSnapInterval=0</compile-flags>
       <baseline>enumerableRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -77,7 +77,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=enumerableTest -TTDStartEvent=2</compile-flags>
       <baseline>enumerableReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -85,7 +85,7 @@
       <files>enumeratingWithES5.js</files>
       <compile-flags>-TTRecord=enumeratingWithES5Test -TTSnapInterval=0</compile-flags>
       <baseline>enumeratingWithES5Record.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -93,7 +93,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=enumeratingWithES5Test -TTDStartEvent=2</compile-flags>
       <baseline>enumeratingWithES5Replay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -101,7 +101,7 @@
       <files>enumerationAddDelete.js</files>
       <compile-flags>-TTRecord=enumerationAddDeleteTest -TTSnapInterval=0</compile-flags>
       <baseline>enumerationAddDeleteRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -109,7 +109,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=enumerationAddDeleteTest -TTDStartEvent=2</compile-flags>
       <baseline>enumerationAddDeleteReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -117,7 +117,7 @@
       <files>forEach.js</files>
       <compile-flags>-TTRecord=forEachTest -TTSnapInterval=0</compile-flags>
       <baseline>forEachRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -125,7 +125,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=forEachTest -TTDStartEvent=2</compile-flags>
       <baseline>forEachReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -133,7 +133,7 @@
       <files>forInArrayAdd.js</files>
       <compile-flags>-TTRecord=forInArrayAddTest -TTSnapInterval=0</compile-flags>
       <baseline>forInArrayAddRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -141,7 +141,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=forInArrayAddTest -TTDStartEvent=2</compile-flags>
       <baseline>forInArrayAddReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -149,7 +149,7 @@
       <files>forInObjectAdd.js</files>
       <compile-flags>-TTRecord=forInObjectAddTest -TTSnapInterval=0</compile-flags>
       <baseline>forInObjectAddRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -157,7 +157,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=forInObjectAddTest -TTDStartEvent=2</compile-flags>
       <baseline>forInObjectAddReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -165,7 +165,7 @@
       <files>forInObjectAddDelete.js</files>
       <compile-flags>-TTRecord=forInObjectAddDeleteTest -TTSnapInterval=0</compile-flags>
       <baseline>forInObjectAddDeleteRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -173,7 +173,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=forInObjectAddDeleteTest -TTDStartEvent=2</compile-flags>
       <baseline>forInObjectAddDeleteReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -181,7 +181,7 @@
       <files>forInObjectDelete.js</files>
       <compile-flags>-TTRecord=forInObjectDeleteTest -TTSnapInterval=0</compile-flags>
       <baseline>forInObjectDeleteRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -189,7 +189,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=forInObjectDeleteTest -TTDStartEvent=2</compile-flags>
       <baseline>forInObjectDeleteReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -197,7 +197,7 @@
       <files>symbolFor.js</files>
       <compile-flags>-TTRecord=symbolForTest -TTSnapInterval=0</compile-flags>
       <baseline>symbolForRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -205,7 +205,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=symbolForTest -TTDStartEvent=2</compile-flags>
       <baseline>symbolForReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -213,7 +213,7 @@
       <files>try.js</files>
       <compile-flags>-TTRecord=tryTest -TTSnapInterval=0</compile-flags>
       <baseline>tryRecord.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
   <test>
@@ -221,7 +221,7 @@
       <files>ttdSentinal.js</files>
       <compile-flags>-TTReplay=tryTest -TTDStartEvent=2</compile-flags>
       <baseline>tryReplay.baseline</baseline>
-      <tags>exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized</tags>
+      <tags>exclude_dynapogo,exclude_snap,exclude_serialized</tags>
     </default>
   </test>
 </regress-exe>

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -719,7 +719,6 @@
     <default>
       <files>ProxyPropertiesAPI.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>

--- a/test/es6module/rlexe.xml
+++ b/test/es6module/rlexe.xml
@@ -73,7 +73,6 @@
     <default>
       <files>dynamic_import_promises_5796.js</files>
       <compile-flags>-ESDynamicImport</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
@@ -144,7 +143,7 @@
       <files>bug_issue_3257.js</files>
       <compile-flags>-ESDynamicImport</compile-flags>
       <baseline>bug_issue_3257.baseline</baseline>
-      <tags>exclude_sanitize_address,exclude_jshost</tags>
+      <tags>exclude_sanitize_address</tags>
     </default>
   </test>
   <test>
@@ -171,23 +170,18 @@
     <default>
       <files>GetModuleNamespace.js</files>
       <compile-flags>-ESDynamicImport</compile-flags>
-      <tags>exclude_jshost,exclude_sanitize_address</tags>
+      <tags>exclude_sanitize_address</tags>
     </default>
   </test>
   <test>
     <default>
       <files>module-load-twice.js</files>
-      <!-- This test is designed for ch only. -->
-      <!-- todo: enable using source code copy for jshost? -->
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
     <default>
       <files>passmodule.js</files>
-      <!-- This test is designed for ch only - to test the -module flag. -->
       <compile-flags>-module</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
@@ -208,14 +202,12 @@
     <default>
       <files>ImportMeta.js</files>
       <compile-flags>-args summary -endargs -esimportmeta</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>
     <default>
       <files>top-level-await.js</files>
       <compile-flags>-ESDynamicImport -ESTopLevelAwait -module</compile-flags>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
 </regress-exe>

--- a/test/es7/rlexe.xml
+++ b/test/es7/rlexe.xml
@@ -92,7 +92,6 @@
       <files>PromiseRejectionTracking.js</files>
       <compile-flags>-TrackRejectedPromises -args summary -endargs -nodeferparse</compile-flags>
       <baseline>PromiseRejectionTracking.baseline</baseline>
-      <tags>exclude_jshost</tags>
     </default>
   </test>
   <test>

--- a/test/rlexedirs.xml
+++ b/test/rlexedirs.xml
@@ -23,7 +23,7 @@
 <dir>
   <default>
     <files>ConfigParsing</files>
-    <tags>exclude_jshost,exclude_xplat</tags>
+    <tags>exclude_xplat</tags>
   </default>
 </dir>
 <dir>
@@ -315,7 +315,7 @@
 <dir>
   <default>
     <files>WasmSpec</files>
-    <tags>exclude_serialized,require_backend,exclude_jshost,exclude_win7,require_wasm</tags>
+    <tags>exclude_serialized,require_backend,exclude_win7,require_wasm</tags>
   </default>
 </dir>
 <dir>
@@ -333,25 +333,25 @@
 <dir>
   <default>
     <files>Debugger</files>
-    <tags>exclude_serialized,exclude_jshost,exclude_snap,require_debugger,exclude_sanitize_address</tags>
+    <tags>exclude_serialized,exclude_snap,require_debugger,exclude_sanitize_address</tags>
   </default>
 </dir>
 <dir>
   <default>
     <files>DebuggerCommon</files>
-    <tags>exclude_serialized,exclude_jshost,exclude_snap,require_debugger,exclude_sanitize_address</tags>
+    <tags>exclude_serialized,exclude_snap,require_debugger,exclude_sanitize_address</tags>
   </default>
 </dir>
 <dir>
   <default>
     <files>TTExecuteBasic</files>
-    <tags>sequential,exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized,require_debugger,exclude_sanitize_address</tags>
+    <tags>sequential,exclude_dynapogo,exclude_snap,exclude_serialized,require_debugger,exclude_sanitize_address</tags>
   </default>
 </dir>
 <dir>
   <default>
     <files>TTBasic</files>
-    <tags>sequential,exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized,require_debugger,exclude_sanitize_address</tags>
+    <tags>sequential,exclude_dynapogo,exclude_snap,exclude_serialized,require_debugger,exclude_sanitize_address</tags>
   </default>
 </dir>
 <dir>

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -524,10 +524,6 @@ goto :main
   set _rlArgs=%_rlArgs% -nottags:exclude_%_BuildTypeMapped%
   set _rlArgs=%_rlArgs% -nottags:exclude_%_NewBuildTypeMapped%
 
-  if [%_JSHOST%] NEQ [1] (
-    set _rlArgs=%_rlArgs% -nottags:exclude_ch
-  )
-
   set _rlArgs=%_rlArgs% %_exclude_serialized%
   set _rlArgs=%_rlArgs% %_exclude_forcedeferparse%
   set _rlArgs=%_rlArgs% %_exclude_nodeferparse%

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -49,7 +49,7 @@ else
 fi
 
 if [[ $release_build != 1 ]]; then
-    "$test_path/runtests.py" $build_type --not-tag exclude_jenkins --not-tag exclude_ch $test_variant
+    "$test_path/runtests.py" $build_type --not-tag exclude_jenkins $test_variant
     if [[ $? != 0 ]]; then
         exit 1
     fi

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -309,7 +309,7 @@ Below test fails with difference in space. Investigate the cause and re-enable t
     <default>
       <files>Uint8ClampedArray.js</files>
       <baseline>Uint8ClampedArray_es6.baseline</baseline>
-      <tags>typedarray,exclude_jshost</tags> <!-->Disabled jshost, created issue #5520<!-->
+      <tags>typedarray</tags> <!-->Disabled jshost, created issue #5520<!-->
     </default>
   </test>
   <test>

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -4,42 +4,42 @@
   <default>
     <files>unsigned.js</files>
     <compile-flags>-wasm -args 0 5 -endargs</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>unsigned.js</files>
     <compile-flags>-wasm -args 6 10 -endargs</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>unsigned.js</files>
     <compile-flags>-wasm -args 11 15 -endargs</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>unsigned.js</files>
     <compile-flags>-wasm -args 16 20 -endargs</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>unsigned.js</files>
     <compile-flags>-wasm -args 21 -endargs</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>regress.js</files>
     <compile-flags>-wasm -args --no-verbose -endargs</compile-flags>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_win7</tags>
   </default>
 </test>
 <test>
@@ -86,14 +86,14 @@
   <default>
     <files>f32.js</files>
     <compile-flags>-wasm</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>f64.js</files>
     <compile-flags>-wasm</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
@@ -126,14 +126,14 @@
   <default>
     <files>divByConstants.js</files>
     <compile-flags>-wasm  </compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>divByConstants_unsigned.js</files>
     <compile-flags>-wasm  </compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
@@ -179,7 +179,7 @@
 <test>
   <default>
     <files>table_signatures.js</files>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
     <compile-flags>-wasm -args --no-verbose -endargs</compile-flags>
   </default>
 </test>
@@ -220,7 +220,7 @@
   <default>
     <files>bugs.js</files>
     <compile-flags>-wasm</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
@@ -228,14 +228,14 @@
     <files>params.js</files>
     <baseline>baselines/params.baseline</baseline>
     <compile-flags>-wasm -EnableFatalErrorOnOOM- -args 14000 -endargs</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7,exclude_dynapogo,exclude_sanitize_address</tags>
+    <tags>exclude_drt,exclude_win7,exclude_dynapogo,exclude_sanitize_address</tags>
   </default>
 </test>
 <test>
   <default>
     <files>inlining.js</files>
     <baseline>inlining.baseline</baseline>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_win7</tags>
   </default>
 </test>
 <test>
@@ -243,28 +243,28 @@
     <files>params.js</files>
     <baseline>baselines/params.baseline</baseline>
     <compile-flags>-wasm -args 14000 -endargs</compile-flags>
-    <tags>exclude_jshost,exclude_win7,exclude_dynapogo</tags>
+    <tags>exclude_win7,exclude_dynapogo</tags>
   </default>
 </test>
   <test>
     <default>
       <files>debugger_basic.js</files>
       <compile-flags>-wasm -dbgbaseline:debugger_basic.js.dbg.baseline</compile-flags>
-      <tags>exclude_jshost,exclude_win7,exclude_drt,exclude_snap,require_debugger</tags>
+      <tags>exclude_win7,exclude_drt,exclude_snap,require_debugger</tags>
     </default>
   </test>
   <test>
     <default>
       <files>debugger_basic.js</files>
       <compile-flags>-wasm -maic:1 -dbgbaseline:debugger_basic.js.dbg.baseline</compile-flags>
-      <tags>exclude_jshost,exclude_win7,exclude_drt,exclude_snap,require_debugger</tags>
+      <tags>exclude_win7,exclude_drt,exclude_snap,require_debugger</tags>
     </default>
   </test>
   <test>
     <default>
       <files>debugger_basic.js</files>
       <compile-flags>-wasm -debuglaunch -args debuglaunch -endargs -dbgbaseline:debugger_basic_launch.js.dbg.baseline</compile-flags>
-      <tags>exclude_jshost,exclude_win7,exclude_drt,exclude_snap,require_debugger</tags>
+      <tags>exclude_win7,exclude_drt,exclude_snap,require_debugger</tags>
     </default>
   </test>
   <test>
@@ -272,7 +272,7 @@
       <files>wasmcctx.js</files>
       <compile-flags>-wasm -dbgbaseline:wasmcctx.js.dbg.baseline -InspectMaxStringLength:50</compile-flags>
       <!-- todo-xplat: Fix this! The test is flaky on XPLAT -->
-      <tags>exclude_jshost,exclude_win7,exclude_drt,exclude_snap,require_debugger,exclude_xplat</tags>
+      <tags>exclude_win7,exclude_drt,exclude_snap,require_debugger,exclude_xplat</tags>
     </default>
   </test>
 <test>
@@ -309,7 +309,7 @@
     <files>response.js</files>
     <baseline>baselines/response.baseline</baseline>
     <compile-flags>-wasm</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
@@ -329,7 +329,7 @@
   <default>
     <files>nestedblocks.js</files>
     <compile-flags>-wasm</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7,exclude_dynapogo</tags>
+    <tags>exclude_drt,exclude_win7,exclude_dynapogo</tags>
   </default>
 </test>
 <test>
@@ -337,35 +337,35 @@
     <files>cse.js</files>
     <baseline>baselines/cse.baseline</baseline>
     <compile-flags>-wasm -maic:0 -WasmAssignModuleID -testtrace:cse:2.0-99.999</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7,exclude_interpreted,exclude_sanitize_address</tags>
+    <tags>exclude_drt,exclude_win7,exclude_interpreted,exclude_sanitize_address</tags>
   </default>
 </test>
 <test>
   <default>
     <files>signextend.js</files>
     <compile-flags>-wasm -args --no-verbose -endargs</compile-flags>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>memory.js</files>
     <compile-flags>-wasm</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>memory.js</files>
     <compile-flags>-wasm -wasmfastarray-</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>superlongsignaturemismatch.js</files>
     <compile-flags>-wasm</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
+    <tags>exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>
@@ -384,7 +384,7 @@
   <default>
     <files>polyinline.js</files>
     <compile-flags>-maxinterpretcount:2 -off:simplejit</compile-flags>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_win7</tags>
   </default>
 </test>
 <test>
@@ -392,7 +392,7 @@
     <files>limits.js</files>
     <compile-flags>-wasm -args --no-verbose --end 4 -endargs</compile-flags>
     <timeout>300</timeout>
-    <tags>exclude_jshost,exclude_drt,exclude_win7,exclude_debug,exclude_dynapogo,exclude_x86,Slow</tags>
+    <tags>exclude_drt,exclude_win7,exclude_debug,exclude_dynapogo,exclude_x86,Slow</tags>
   </default>
 </test>
 <test>
@@ -400,7 +400,7 @@
     <files>limits.js</files>
     <compile-flags>-wasm -args --no-verbose --start 4 --end 12 -endargs</compile-flags>
     <timeout>300</timeout>
-    <tags>exclude_jshost,exclude_drt,exclude_win7,exclude_debug,exclude_dynapogo,exclude_x86,Slow</tags>
+    <tags>exclude_drt,exclude_win7,exclude_debug,exclude_dynapogo,exclude_x86,Slow</tags>
   </default>
 </test>
 <test>
@@ -408,35 +408,35 @@
     <files>limits.js</files>
     <compile-flags>-wasm -args --no-verbose --start 12 -endargs</compile-flags>
     <timeout>300</timeout>
-    <tags>exclude_jshost,exclude_drt,exclude_win7,exclude_debug,exclude_dynapogo,exclude_x86,Slow</tags>
+    <tags>exclude_drt,exclude_win7,exclude_debug,exclude_dynapogo,exclude_x86,Slow</tags>
   </default>
 </test>
 <test>
   <default>
     <files>loopstslot.js</files>
     <compile-flags>-forcejitloopbody</compile-flags>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>loopyield.js</files>
     <compile-flags>-forcejitloopbody</compile-flags>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>loopyieldnested.js</files>
     <compile-flags>-lic:10 -bgjit-</compile-flags>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_win7</tags>
   </default>
 </test>
 <test>
   <default>
     <files>loopyieldtypes.js</files>
     <compile-flags>-forcejitloopbody</compile-flags>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_win7</tags>
   </default>
 </test>
 <test>
@@ -456,7 +456,6 @@
   <default>
     <files>reload.js</files>
     <compile-flags>-wasmthreads -ESSharedArrayBuffer</compile-flags>
-    <tags>exclude_jshost</tags>
   </default>
 </test>
 </regress-exe>


### PR DESCRIPTION
Improve runtests.py
- remove unnecessary logfile
- print a welcome message saying that the tests are being run and how many threads are being used
- don't print individual test passes by default (add show-passes flag for printing these if wanted)
- don't print "Running interpreted variant" twice
- print results for a set of tests including time taken before beginning the next set
- other formatting improvements
- remove defunct logic and switches related to ChakraFull