### PR TITLE
Update project docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,17 +8,20 @@ These two blogs posts on contributing code to open source projects are a good re
 
 ## Security
 
-If you believe you have found a security issue in ChakraCore, please share it with us privately following the guidance at the Microsoft [Security TechCenter](https://www.microsoft.com/en-us/msrc/faqs-report-an-issue). Reporting it via this channel helps minimize risk to projects built with ChakraCore.
+If you believe you have found a security issue in ChakraCore 1.11, please share it with Microsoft privately following the guidance at the Microsoft [Security TechCenter](https://technet.microsoft.com/en-us/security/ff852094). Reporting it via this channel helps minimize risk to projects built with ChakraCore.
+
+If you find a security issue in the Master branch of ChakraCore but not in 1.11 please join our discord server and private message one of the Core team members.
 
 ## Legal
 
-You will need to complete a Contributor License Agreement (CLA) before your pull request can be accepted. This agreement testifies that you are granting us permission to use the source code you are submitting, and that this work is being submitted under appropriate license that we can use it.
+You will need to complete a Contribution Agreement before your pull request can be accepted. This agreement testifies that you are granting us permission to use the source code you are submitting, and that this work is being submitted under appropriate license that we can use it.
 
-You can complete the CLA by going through the steps at https://cla.microsoft.com. Once we have received the signed CLA, we'll review the request. You will only need to do this once.
+You can read the agreement here: [Contribution Agreement](Contribution%20Agreement.md)
 
 ## Housekeeping
 
 Your pull request should:
+
 * Include a description of what your change intends to do
 * Be a child commit of a reasonably recent commit in the master branch
 * Pass all unit tests
@@ -28,15 +31,17 @@ Your pull request should:
   * Tests should include reasonable permutations of the target fix/change
   * Include baseline changes with your change
 
-Submissions that have met these requirements will be assigned to a ChakraCore team member for additional testing. Submissions must meet functional and performance expectations, including meeting requirements in scenarios for which the team doesn’t yet have open source tests. This means you may be asked to fix and resubmit your pull request against a new open test case if it fails one of these tests. The ChakraCore team may verify your change by crawling the web with your change built into Chakra. Failures discovered when testing with this technique will not be analyzed by the team, but we will do our best to communicate the issue discovered to you. This approach needs further refinement, we acknowledge.
+Submissions that have met these requirements will be will reviewed by a core contributor. Submissions must meet functional and performance expectations, including meeting requirements in scenarios for which the team doesn’t yet have open source tests. This means you may be asked to fix and resubmit your pull request against a new open test case if it fails one of these tests.
 
-ChakraCore is an organically grown codebase. The consistency of style reflects this. For the most part, the team follows these [coding conventions](https://github.com/Microsoft/ChakraCore/wiki/Coding-Convention). Contributors should also follow them when making submissions. Otherwise, follow the general coding conventions adhered to in the code surrounding your changes. Pull requests that reformat the code will not be accepted.
+ChakraCore is an organically grown codebase. The consistency of style reflects this. For the most part, the team follows these [coding conventions](https://github.com/chakra-core/ChakraCore/wiki/Coding-Convention). Contributors should also follow them when making submissions. Otherwise, follow the general coding conventions adhered to in the code surrounding your changes. Pull requests that reformat the code will not be accepted.
 
 ## Running the tests
 
-The unit tests can be run by following these steps:
-* Choose a build configuration to build and test, e.g. debug and x64.
-* Build `Chakra.Core.sln` for that config.
+The unit tests can be run offline with following these steps:
+
+### a) Windows
+
+* Build `Chakra.Core.sln` for the version of ChakraCore you wish to test e.g. x64 Debug.
   * Specifically, running tests requires that `rl.exe`, `ch.exe`, and `ChakraCore.dll` be built.
 * Call `test\runtests.cmd` and specify the build config
 
@@ -49,20 +54,25 @@ For full coverage, please run unit tests against debug and test for both x86 and
 * `test\runtests.cmd -x86test`
 
 `runtests.cmd` can take more switches that are useful for running a subset of tests.  Read the script file for more information.
-
 `runtests.cmd` looks for the build output in the default build output folder `Build\VcBuild\bin`. If the build output path is changed from this default then use the `-bindir` switch to specify that path.
 
-## Code Flow into Microsoft Edge
+### b) Linux or macOS
 
-Changes that make it into our ChakraCore GitHub master branch have a short journey to Chakra.dll. Code flows daily from GitHub to the internal repository from which builds of Chakra.dll are produced and then it flows into Windows and Microsoft Edge. While code flows quickly on this first leg of the journey, code flow from our internal branch to a Windows flighting branch is subject to any number of delays. So it is difficult to predict when your change in our GitHub repo will make it into a particular Windows flight.
+Build the version of ChakraCore you wish to test - either a Debug or Test (RelWithDebugInfo) build. You will need the ChakraCore library and the `ch` application built.
+
+If building with `cmake` you can then use the `make check` or `ninja check` command to run the test suite.
+Alternatively you can directly run `test/runtests.py` you'll need to specify `-t` (Test build) or `-d` (Debug build).
+
+`runtests.py` can take more switches that are useful for running a subset of tests.  Read the script file for more information.
+`runtests.py` looks for the build output in the default build output folder `out/test/ch` or `out/debug/ch`. If you've used a different path then use `--binary=path` to specify it
 
 ## Issue Labels
 
- - [`help wanted`](https://github.com/Microsoft/ChakraCore/labels/help%20wanted): these issues are specifically well suited for outside contributors.
- - [`good first issue`](https://github.com/Microsoft/ChakraCore/labels/good%20first%20issue): these issues are small and appropriate for people who wish to familiarize themselves with GitHub pull requests and/or ChakraCore's contributor guidelines, build process, and running tests.  We're here to help you get started in open source.
+ - [`help wanted`](https://github.com/chakra-core/ChakraCore/labels/help%20wanted): these issues are specifically well suited for outside contributors.
+ - [`good first issue`](https://github.com/chakra-core/ChakraCore/labels/good%20first%20issue): these issues are small and appropriate for people who wish to familiarize themselves with GitHub pull requests and/or ChakraCore's contributor guidelines, build process, and running tests.  We're here to help you get started in open source.
 
-You are welcome to work on issues that are not tagged with these labels. However, issues without these labels are often deeply involved with the requirements of the various components of ChakraCore. Therefore, please be sure to touch base with a maintainer via comments on the issue before attempting to solve it.
+You are welcome to work on issues that are not tagged with these labels. However, issues without these labels may be fairly complex, therefore please discuss with a core team member via comments on the issue before attempting to solve it.
 
-Remember, for all issues you choose to work on please communicate on the issue that you are claiming it to avoid duplicated work.
+For all issues you choose to work on please communicate on the issue that you are claiming it to avoid duplicated work.
 
 To learn more about our GitHub labels see the [Label Glossary](https://github.com/Microsoft/ChakraCore/wiki/Label-Glossary) on our wiki page.

--- a/Contribution Agreement.md
+++ b/Contribution Agreement.md
@@ -31,3 +31,7 @@ b) my employer has agreed to these terms and signed the agreement
 
 This agreement has been signed by:
 
+| Name | Github username |
+|---|---|
+|Richard Lawrence| rhuanjl|
+

--- a/Contribution Agreement.md
+++ b/Contribution Agreement.md
@@ -1,0 +1,33 @@
+# Contributor Agreement
+
+All contributors to ChakraCore must digitally sign the below agreement unless their contribution is done on behalf of or licensed to Microsoft and covered by the MIT license in LICENSE.txt
+
+To sign the agreement please submit a commit that adds your name and github username to the bottom of this file.
+
+Anything I contribute to the ChakraCore repository is comprised of one or more of:
+
+1. My own work
+2. Existing code from the ChakraCore repository
+3. The work of a group of individuals all of whom agree to (and have signed) these terms
+4. Third party work licensed under terms that enable it to be incorporated into the ChakraCore project
+
+In the case of option 4 I will discuss this Third Party submission with the ChakraCore core contributors before submitting it.
+
+I agree that all contributions I submit will be included in ChakraCore and licensed under the license in LICENSE.txt.
+
+I surrender any rights that would prevent my contribution from being redistributed and used under the license in LICENSE.txt.
+
+I accept that future users of the ChakraCore including my contributions will not be required to give me any acknowledgement except as a "ChakraCore Project Contributor" as mentioned in LICENSE.txt.
+
+I agree that I will never pursue royalties or patent claims related to any contribution to ChakraCore.
+
+I confirm that I have the right to submit this contribution and it can be redistributed under the license in LICENSE.txt.
+
+I agree that a record of my contribution including comments and my name may be retained and displayed publicly in the ChakraCore repository.
+
+If I make any contributions in the course of my employment, then either:
+a) my employer has given my sufficient rights over the work I have done to submit it under the above terms or
+b) my employer has agreed to these terms and signed the agreement
+
+This agreement has been signed by:
+

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) Microsoft Corporation
 All rights reserved.
+Copyright (c) 2021 ChakraCore Project Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # ChakraCore
 
-[![Join the chat at https://gitter.im/Microsoft/ChakraCore](https://badges.gitter.im/Microsoft/ChakraCore.svg)](https://gitter.im/Microsoft/ChakraCore?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Discord Chat](https://img.shields.io/discord/695166668967510077?label=Discord&logo=Discord)](https://discord.gg/3e49Ptz)
 [![Licensed under the MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt)
 [![PR's Welcome](https://img.shields.io/badge/PRs%20-welcome-brightgreen.svg)](#contribute)
 
-ChakraCore is the core part of Chakra, the high-performance JavaScript engine that powers Windows applications written in HTML/CSS/JS and used to power Microsoft Edge.  ChakraCore supports Just-in-time (JIT) compilation of JavaScript for x86/x64/ARM, garbage collection, and a wide range of the latest JavaScript features.  ChakraCore also supports the [JavaScript Runtime (JSRT) APIs](https://github.com/Microsoft/ChakraCore/wiki/JavaScript-Runtime-%28JSRT%29-Overview), which allows you to easily embed ChakraCore in your applications.
+ChakraCore is a Javascript engine with a C API you can use to add support for Javascript to any C or C compatible project. It can be compiled for x64 processors on Linux macOS and Windows. And x86 and ARM for windows only. It is a future goal to support x86 and ARM processors on Linux and ARM on macOS. 
 
 ## Future of ChakraCore
 
-As you may have heard Microsoft Edge no longer uses Chakra. Microsoft will continue to provide security updates for Chakracore 1.11 until 9th March 2021 but do not intend to support it after that.
+As you may have heard Microsoft Edge no longer uses Chakra. Microsoft will continue to provide security updates for ChakraCore 1.11 until 9th March 2021 but do not intend to support it after that.
 
-However ChakraCore is planned to continue as a community project targeted primarily at embedded use cases. We hope to produce future releases with new features and enhancements to support such use cases. We also would like to invite any interested parties to be involved in this project. For further details please see the following draft planning documents:
+ChakraCore is planned to continue as a community project targeted primarily at embedded use cases. We hope to produce future releases with new features and enhancements to support such use cases. We also would like to invite any interested parties to be involved in this project. For further details please see the following draft planning documents:
 [Overall plan](https://github.com/chakra-core/org/blob/master/ChakraCore%20Future%20Plan.md)
 [Version 1.12 plan](https://github.com/chakra-core/org/blob/master/Release%201.12%20plan.md)
 
@@ -19,35 +18,19 @@ Also see discussion in issue [#6384](https://github.com/microsoft/ChakraCore/iss
 
 If you'd like to contact the community team please either open an issue or join the discord chat linked above.
 
-## Build Status
-
-|                               | __Debug__ | __Test__ | __Release__ |
-|:-----------------------------:|:---------:|:--------:|:-----------:|
-| __Windows 10 (x64)__             | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20x64_debug)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20x64_test)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20x64_release)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) |
-| __Windows 10 (x86)__             | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20x86_debug)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20x86_test)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20x86_release)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) |
-| __Windows 10 (ARM)__             | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20arm_debug)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20arm_test)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20arm_release)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) |
-| __Windows 10 (ARM64)__           | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20arm64_debug)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20arm64_test)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Windows%2010%20-%20daily?branchName=master&jobName=Build%5Cscripts%5C*.ps1&configuration=Build%5Cscripts%5C*.ps1%20arm64_release)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=50&branchName=master) |
-| __Ubuntu 16.04 (x64)<sup>[a]</sup>__     | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Linux%20(Ubuntu%2016.04)%20-%20daily?branchName=master&jobName=static%20debug)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=51&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Linux%20(Ubuntu%2016.04)%20-%20daily?branchName=master&jobName=static%20test)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=51&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Linux%20(Ubuntu%2016.04)%20-%20daily?branchName=master&jobName=static%20release)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=51&branchName=master) |
-| __Ubuntu 16.04 (x64)<sup>[s]</sup>__     | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Linux%20(Ubuntu%2016.04)%20-%20daily?branchName=master&jobName=shared%20debug)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=51&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Linux%20(Ubuntu%2016.04)%20-%20daily?branchName=master&jobName=shared%20test)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=51&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Linux%20(Ubuntu%2016.04)%20-%20daily?branchName=master&jobName=shared%20release)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=51&branchName=master) |
-| __Ubuntu 16.04 (x64)<sup>[s][n]</sup>__  | * | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/Linux%20(Ubuntu%2016.04)%20-%20daily?branchName=master&jobName=no%20jit%20shared%20test%20)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=51&branchName=master) | * |
-| __macOS 10.13 (x64)<sup>[a]</sup>__        | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/macOS%20-%20daily?branchName=master&jobName=static%20debug)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=52&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/macOS%20-%20daily?branchName=master&jobName=static%20test)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=52&branchName=master) | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/macOS%20-%20daily?branchName=master&jobName=static%20release)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=52&branchName=master) |
-| __macOS 10.13 (x64)<sup>[s][n]</sup>__     | * | [![Build Status](https://chakrateam.visualstudio.com/Push_Build_Runner/_apis/build/status/daily/macOS%20-%20daily?branchName=master&jobName=no%20jit%20shared%20test%20)](https://chakrateam.visualstudio.com/Push_Build_Runner/_build/latest?definitionId=52&branchName=master) | * |
-
-<sup>[a]</sup> Static | <sup>[s]</sup> Shared | <sup>[n]</sup> NoJIT | * Omitted
-
-Above is a table of our rolling build status. We run additional builds on a daily basis. See [Build Status](https://github.com/Microsoft/ChakraCore/wiki/Build-Status) for the status of all builds and additional details.
-
 ## Security
 
-If you believe you have found a security issue in ChakraCore, please share it with us privately following the guidance at the Microsoft [Security TechCenter](https://technet.microsoft.com/en-us/security/ff852094). Reporting it via this channel helps minimize risk to projects built with ChakraCore.
+If you believe you have found a security issue in ChakraCore 1.11, please share it with Microsoft privately following the guidance at the Microsoft [Security TechCenter](https://technet.microsoft.com/en-us/security/ff852094). Reporting it via this channel helps minimize risk to projects built with ChakraCore.
+
+If you find a security issue in the Master branch of Chakracore but not in 1.11 please join our discord server and private message one of the Core team members.
 
 ## Documentation
 
-* [ChakraCore Architecture](https://github.com/Microsoft/ChakraCore/wiki/Architecture-Overview)
-* [Quickstart Embedding ChakraCore](https://github.com/Microsoft/ChakraCore/wiki/Embedding-ChakraCore)
-* [JSRT Reference](https://github.com/Microsoft/ChakraCore/wiki/JavaScript-Runtime-%28JSRT%29-Reference)
+* [ChakraCore Architecture](https://github.com/chakra-core/ChakraCore/wiki/Architecture-Overview)
+* [Quickstart Embedding ChakraCore](https://github.com/chakra-core/ChakraCore/wiki/Embedding-ChakraCore)
+* [API Reference](https://github.com/chakra-core/ChakraCore/wiki/JavaScript-Runtime-%28JSRT%29-Reference)
 * [Contribution guidelines](CONTRIBUTING.md)
-* [Blogs, talks and other resources](https://github.com/Microsoft/ChakraCore/wiki/Resources)
+* [Blogs, talks and other resources](https://github.com/chakra-core/ChakraCore/wiki/Resources)
 
 ## Building ChakraCore
 
@@ -57,7 +40,10 @@ You can build ChakraCore on Windows 7 SP1 or above, and Windows Server 2008 R2 o
 * Open `Build\Chakra.Core.sln` in Visual Studio
 * Build Solution
 
-More details in [Building ChakraCore](https://github.com/Microsoft/ChakraCore/wiki/Building-ChakraCore).
+On macOS you can build ChakraCore with the xcode command line tools and `cmake`.
+On Linux you can build ChakraCore with `cmake` and `ninja`.
+
+More details in [Building ChakraCore](https://github.com/chakra-core/ChakraCore/wiki/Building-ChakraCore).
 
 Alternatively, see [Getting ChakraCore binaries](https://github.com/Microsoft/ChakraCore/wiki/Getting-ChakraCore-binaries) for pre-built ChakraCore binaries.
 
@@ -65,13 +51,12 @@ Alternatively, see [Getting ChakraCore binaries](https://github.com/Microsoft/Ch
 
 Once built, you have a few options for how you can use ChakraCore:
 
-* The most basic is to test the engine is running correctly with the *ch.exe* binary.  This app is a lightweight hosting of JSRT that you can use to run small applications.  After building, you can find this binary in:
-  * `Build\VcBuild\bin\${platform}_${configuration}`
-  * (e.g. `Build\VcBuild\bin\x64_debug`)
-* You can [embed ChakraCore](https://github.com/Microsoft/ChakraCore/wiki/Embedding-ChakraCore) in your applications - see [documentation](https://github.com/Microsoft/ChakraCore/wiki/Embedding-ChakraCore) and [samples](https://aka.ms/chakracoresamples).
-* Finally, you can also use ChakraCore as the JavaScript engine in Node.  You can learn more by reading how to use [Chakra as Node's JS engine](https://github.com/Microsoft/node)
+* The most basic is to test the engine is running correctly with the application *ch.exe* (ch on linux or macOS).  This app is a lightweight host of ChakraCore that you can use to run small applications.  After building, you can find this binary in:
+  * Windows: `Build\VcBuild\bin\${platform}_${configuration}` (e.g. `Build\VcBuild\bin\x64_debug`)
+  * Mac/Linux: `buildFolder/config/ch` (e.g. `out/Release/ch`)
+* You can [embed ChakraCore](https://github.com/chakra-core/ChakraCore/wiki/Embedding-ChakraCore) in your applications - see [documentation](https://github.com/chakra-core/ChakraCore/wiki/Embedding-ChakraCore) and [samples](https://aka.ms/chakracoresamples).
 
-_A note about using ChakraCore_: ChakraCore is the foundational JavaScript engine, but it does not include the external APIs that make up the modern JavaScript development experience.  For example, DOM APIs like ```document.write()``` are additional APIs that are not available by default and would need to be provided.  For debugging, you may instead want to use ```print()```.
+_A note about using ChakraCore_: ChakraCore is a JavaScript engine, it does not include the external APIs that are provided by a Web Browser or nodejs.  For example, DOM APIs like ```document.write()``` are additional APIs that are not provided by ChakraCore, when embedding ChakraCore in an application you will need to implement your own input and output APIs.  For debugging, in `ch` you can use ```print()``` to put text to the terminal.
 
 Alternatively, if you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can download and install ChakraCore with CMake integration in a single command:
 * vcpkg install chakracore
@@ -80,26 +65,18 @@ Alternatively, if you are using the [vcpkg](https://github.com/Microsoft/vcpkg/)
 
 Contributions to ChakraCore are welcome.  Here is how you can contribute to ChakraCore:
 
-* [Submit bugs](https://github.com/Microsoft/ChakraCore/issues) and help us verify fixes (please refer to [External Issues](https://github.com/Microsoft/ChakraCore/wiki/External-Issues) for anything external, such as Microsoft Edge or Node-ChakraCore issues)
-* [Submit pull requests](https://github.com/Microsoft/ChakraCore/pulls) for bug fixes and features and discuss existing proposals
-* Chat about [@ChakraCore](https://twitter.com/ChakraCore) on Twitter
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+* [Submit bugs](https://github.com/chakra-core/ChakraCore/issues) and help us verify fixes.
+* [Submit pull requests](https://github.com/chakra-core/ChakraCore/pulls) for bug fixes and features and discuss existing proposals
 
 Please refer to [Contribution Guidelines](CONTRIBUTING.md) for more details.
 
 ## License
 
-Code licensed under the [MIT License](https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt).
-
-## Roadmap
-
-For details on our planned features and future direction please refer to our [Roadmap](https://github.com/Microsoft/ChakraCore/wiki/Roadmap).
+Code licensed under the [MIT License](https://github.com/chakra-core/ChakraCore/blob/master/LICENSE.txt).
 
 ## Contact Us
 
 If you have questions about ChakraCore, or you would like to reach out to us about an issue you're having or for development advice as you work on a ChakraCore issue, you can reach us as follows:
 
-* Open an [issue](https://github.com/Microsoft/ChakraCore/issues/new) and prefix the issue title with [Question]. See [Question](https://github.com/Microsoft/ChakraCore/issues?q=label%3AQuestion) tag for already-opened questions.
-* Discuss ChakraCore with the team and the community on our [Gitter Channel](https://gitter.im/Microsoft/ChakraCore).
-* You can also start private messages with individual ChakraCore developers via Gitter.
+* Open an [issue](https://github.com/chakra-core/ChakraCore/issues/new) and prefix the issue title with [Question]. See [Question](https://github.com/chakra-core/ChakraCore/issues?q=label%3AQuestion) tag for already-opened questions.
+* Discuss ChakraCore with the team and the community via the Discord link above


### PR DESCRIPTION
Update the Readme, contributor guidelines and project license.

Add a new Contribution Agreement for us and all future contributors to accept.

I figure that following from this (assuming we take these changes) we can update the copyright banners in individual files with the additional copyright as and when we update those files rather than all in one go. (Or we could run a script to do them all)

Fix: #6549