### PR TITLE
Remove a target framework from NuGet packages

### DIFF
--- a/Build/NuGet/Microsoft.ChakraCore.ARM.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.ARM.nuspec
@@ -15,14 +15,9 @@
     <copyright>Copyright (C) 2016 Microsoft</copyright>
     <language>en-US</language>
     <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
-    <dependencies>
-      <group targetFramework=".NETStandard1.0" />
-    </dependencies>
   </metadata>
   <files>
-    <file src="_._" target="lib\netstandard1.0\"/>
-
-    <file src="Microsoft.ChakraCore.ARM.props" target="build\netstandard1.0"/>
+    <file src="Microsoft.ChakraCore.ARM.props" target="build" />
 
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native\ChakraCore.dll" />
   </files>

--- a/Build/NuGet/Microsoft.ChakraCore.ARM.props
+++ b/Build/NuGet/Microsoft.ChakraCore.ARM.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win8-ARM\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-ARM\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/Build/NuGet/Microsoft.ChakraCore.Symbols.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.Symbols.nuspec
@@ -15,15 +15,10 @@
     <copyright>Copyright (C) 2016 Microsoft</copyright>
     <language>en-US</language>
     <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
-    <dependencies>
-      <group targetFramework=".NETStandard1.0" />
-    </dependencies>
   </metadata>
   <files>
-    <file src="_._" target="lib\netstandard1.0\"/>
+    <file src="Microsoft.ChakraCore.Symbols.props" target="build" />
 
-    <file src="Microsoft.ChakraCore.Symbols.props" target="build\netstandard1.0"/>
-    
     <file src="..\VcBuild\bin\x86_release\ChakraCore.pdb" target="runtimes\win7-x86\native\ChakraCore.pdb" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.pdb" target="runtimes\win7-x64\native\ChakraCore.pdb" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.pdb" target="runtimes\win8-arm\native\ChakraCore.pdb" />

--- a/Build/NuGet/Microsoft.ChakraCore.Symbols.props
+++ b/Build/NuGet/Microsoft.ChakraCore.Symbols.props
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config')) And '$(Platform)' == 'AnyCPU'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x86\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*">
       <Link>x86\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x64\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*">
       <Link>x64\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
   </ItemGroup>
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config')) And '$(Platform)' == 'x86'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x86\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
   </ItemGroup>
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config')) And '$(Platform)' == 'x64'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x64\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
   </ItemGroup>
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config')) And '$(Platform)' == 'ARM'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win8-arm\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/Build/NuGet/Microsoft.ChakraCore.X64.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.X64.nuspec
@@ -15,15 +15,10 @@
     <copyright>Copyright (C) 2016 Microsoft</copyright>
     <language>en-US</language>
     <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
-    <dependencies>
-      <group targetFramework=".NETStandard1.0" />
-    </dependencies>
   </metadata>
   <files>
-    <file src="_._" target="lib\netstandard1.0\"/>
+    <file src="Microsoft.ChakraCore.X64.props" target="build" />
 
-    <file src="Microsoft.ChakraCore.X64.props" target="build\netstandard1.0"/>
-    
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native\ChakraCore.dll" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.X64.props
+++ b/Build/NuGet/Microsoft.ChakraCore.X64.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x64\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/Build/NuGet/Microsoft.ChakraCore.X86.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.X86.nuspec
@@ -15,15 +15,10 @@
     <copyright>Copyright (C) 2016 Microsoft</copyright>
     <language>en-US</language>
     <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
-    <dependencies>
-      <group targetFramework=".NETStandard1.0" />
-    </dependencies>
   </metadata>
   <files>
-    <file src="_._" target="lib\netstandard1.0\"/>
+    <file src="Microsoft.ChakraCore.X86.props" target="build" />
 
-    <file src="Microsoft.ChakraCore.X86.props" target="build\netstandard1.0"/>
-    
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native\ChakraCore.dll" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.X86.props
+++ b/Build/NuGet/Microsoft.ChakraCore.X86.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x86\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/Build/NuGet/Microsoft.ChakraCore.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.nuspec
@@ -15,15 +15,10 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <language>en-US</language>
     <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
-    <dependencies>
-      <group targetFramework=".NETStandard1.0" />
-    </dependencies>
   </metadata>
   <files>
-    <file src="_._" target="lib\netstandard1.0\"/>
+    <file src="Microsoft.ChakraCore.props" target="build" />
 
-    <file src="Microsoft.ChakraCore.props" target="build\netstandard1.0"/>
-    
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native\ChakraCore.dll" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native\ChakraCore.dll" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native\ChakraCore.dll" />

--- a/Build/NuGet/Microsoft.ChakraCore.props
+++ b/Build/NuGet/Microsoft.ChakraCore.props
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config')) And '$(Platform)' == 'AnyCPU'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x86\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*">
       <Link>x86\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x64\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*">
       <Link>x64\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
   </ItemGroup>
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config') Or Exists('project.json') Or Exists('project.$(MSBuildProjectName).json')) And '$(Platform)' == 'x86'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x86\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
   </ItemGroup>
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config') Or Exists('project.json') Or Exists('project.$(MSBuildProjectName).json')) And '$(Platform)' == 'x64'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x64\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
   </ItemGroup>
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config') Or Exists('project.json') Or Exists('project.$(MSBuildProjectName).json')) And '$(Platform)' == 'ARM'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win8-arm\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>


### PR DESCRIPTION
Current versions of packages are targeted to .NET Standard 1.0, because of this, they cannot be used in projects oriented on .NET Framework 4.0 or earlier. For packages that contain only native assemblies, do not need to specify a target framework. Most likely, creators of packages initially generated a sample `.nuspec` file from C# project and simply did not clean up it. Therefore, we can safely remove the target framework.