### PR TITLE
Speed up linux and macOS CI by A LOT

### DIFF
--- a/lib/Common/Codex/CMakeLists.txt
+++ b/lib/Common/Codex/CMakeLists.txt
@@ -1,12 +1,12 @@
-if(NOT STATIC_LIBRARY)
-  # CH has a direct dependency to this project
-  add_library (Chakra.Common.Codex.Singular STATIC
-    Utf8Codex.cpp)
-  target_include_directories (
-    Chakra.Common.Codex.Singular PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-endif()
 add_library (Chakra.Common.Codex OBJECT
     Utf8Codex.cpp)
 
 target_include_directories (
     Chakra.Common.Codex PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(NOT STATIC_LIBRARY)
+  # CH has a direct dependency to this project
+  add_library (Chakra.Common.Codex.Singular STATIC
+    $<TARGET_OBJECTS:Chakra.Common.Codex>)
+endif()
+

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
@@ -378,11 +379,7 @@
 #define RUNTIME_DATA_COLLECTION
 #define SECURITY_TESTING
 
-// xplat-todo: Temporarily disable profile output on non-Win32 builds
-#ifdef _WIN32
 #define PROFILE_EXEC
-#endif
-
 #define BGJIT_STATS
 #define REJIT_STATS
 #define PERF_HINT

--- a/lib/Jsrt/JsrtHelper.cpp
+++ b/lib/Jsrt/JsrtHelper.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -109,7 +110,7 @@ void JsrtCallbackState::ObjectBeforeCallectCallbackWrapper(JsObjectBeforeCollect
 
     // setup the cleanup
     // we do not track the main thread. When it exits do the cleanup below
-#ifdef CHAKRA_STATIC_LIBRARY
+#if defined(CHAKRA_STATIC_LIBRARY) || !defined(_WIN32)
     atexit([]() {
         ThreadBoundThreadContextManager::DestroyContextAndEntryForCurrentThread();
 

--- a/lib/Runtime/Base/ScriptContextProfiler.h
+++ b/lib/Runtime/Base/ScriptContextProfiler.h
@@ -1,17 +1,19 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
 class ServerScriptContext;
+class NativeCodeGenerator;
 namespace Js
 {
     class ScriptContextProfiler
     {
 #ifdef PROFILE_EXEC
-        friend class NativeCodeGenerator;
-        friend class ServerScriptContext;
+        friend class ::NativeCodeGenerator;
+        friend class ::ServerScriptContext;
 
     public:
         ScriptContextProfiler();

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -36,19 +36,6 @@ elseif(CC_TARGET_OS_OSX)
     )
 endif()
 
-if(NOT STATIC_LIBRARY)
-  # CH has a direct dependency to this project
-  add_library (Chakra.Runtime.PlatformAgnostic.Singular STATIC
-    ${PL_SOURCE_FILES}
-    )
-  if (EMBED_ICU)
-    add_dependencies(Chakra.Runtime.PlatformAgnostic.Singular ${EMBEDDED_ICU_TARGET})
-  endif()
-  target_include_directories (
-    Chakra.Runtime.PlatformAgnostic.Singular PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-endif()
-
 add_library (Chakra.Runtime.PlatformAgnostic OBJECT
   ${PL_SOURCE_FILES}
   )
@@ -56,3 +43,10 @@ add_library (Chakra.Runtime.PlatformAgnostic OBJECT
 target_include_directories (
   Chakra.Runtime.PlatformAgnostic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
   )
+
+if(NOT STATIC_LIBRARY)
+  # CH has a direct dependency to this project
+  add_library (Chakra.Runtime.PlatformAgnostic.Singular STATIC
+    $<TARGET_OBJECTS:Chakra.Runtime.PlatformAgnostic>
+    )
+endif()

--- a/pal/src/CMakeLists.txt
+++ b/pal/src/CMakeLists.txt
@@ -180,9 +180,7 @@ endif()
 if (NOT STATIC_LIBRARY)
   add_library(Chakra.Pal.Singular
     STATIC
-    ${SOURCES}
-    ${PLATFORM_SOURCES}
-    ${ARCH_SOURCES}
+    $<TARGET_OBJECTS:Chakra.Pal>
   )
 
   if(CC_TARGET_OS_OSX)
@@ -200,8 +198,4 @@ if (NOT STATIC_LIBRARY)
     ${PTHREAD}
     dl
     )
-
-  if(EMBED_ICU)
-    add_dependencies(Chakra.Pal.Singular ${EMBEDDED_ICU_TARGET})
-  endif()
 endif()


### PR DESCRIPTION
Two important changes, one to speed up the test suite and one to speed up the build.

**1. Fix Dynamic Profile info on macOS and Linux**
- Dynamic profile (DPL) was #ifdef'd out when CC was ported to linux
- DPL is intended for testing
- DPL can store profiling info from the interpreter in a file
- DPL can then be loaded on a future run for use by the jit
- Dynopogo CI on macOS + Unix was trying to load DPL that didn't exist
- It would try multiple times, this added ~2 seconds to every test
- Fixing this therefore makes tests much faster
- Fix was:
   a) enable in CommmonDefines
   b) Fix a compiler error in ScriptContextProfiler AND
   c) Change a condition so the Uninitalize method is called

Running offline this fix makes runtests.py with a RelWithDebInfo build complete in under 180 seconds down from 700+. Running in the CI this has deducted 20-30 minutes from the time taken for RelWithDebInfo test runs.

**2. Don't build ch dependencies twice. In Dynamic linux/macOS builds 3 modules were being built twice:**
- PAL
- PlatformAgnostic
- Codex

This error in CMakeLists files was increasing build times - particularly as PAL was being compiled twice.