### PR TITLE
Downgrade to ubuntu 18 to unblock CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,19 +33,19 @@ jobs:
       maxParallel: 6
       matrix:
         Linux.Debug:
-          image_name: 'ubuntu-latest'
+          image_name: 'ubuntu-18.04'
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'Debug'
           do_test: true
           libtype_flag: ''
         Linux.ReleaseWithDebug:
-          image_name: 'ubuntu-latest'
+          image_name: 'ubuntu-18.04'
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'RelWithDebInfo'
           do_test: true
           libtype_flag: ''
         Linux.Release:
-          image_name: 'ubuntu-latest'
+          image_name: 'ubuntu-18.04'
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'Release'
           do_test: false


### PR DESCRIPTION
@ppenzin This should unblock the CI for the time being

I've opened this issue: https://github.com/chakra-core/ChakraCore/issues/6600 for the Ubuntu 20 build failure