### PR TITLE
Use a `license` element in the `.nuspec` files

### DIFF
--- a/Build/NuGet/Microsoft.ChakraCore.ARM.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.ARM.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>Chakra Team</authors>
     <owners>Chakra Team</owners>
-    <licenseUrl>https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt</licenseUrl>
+    <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
@@ -20,5 +20,7 @@
     <file src="Microsoft.ChakraCore.ARM.props" target="build" />
 
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native\ChakraCore.dll" />
+
+    <file src="..\..\LICENSE.txt" target="" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.Symbols.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.Symbols.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>Chakra Team</authors>
     <owners>Chakra Team</owners>
-    <licenseUrl>https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt</licenseUrl>
+    <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
@@ -22,5 +22,7 @@
     <file src="..\VcBuild\bin\x86_release\ChakraCore.pdb" target="runtimes\win7-x86\native\ChakraCore.pdb" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.pdb" target="runtimes\win7-x64\native\ChakraCore.pdb" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.pdb" target="runtimes\win8-arm\native\ChakraCore.pdb" />
+
+    <file src="..\..\LICENSE.txt" target="" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.X64.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.X64.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>Chakra Team</authors>
     <owners>Chakra Team</owners>
-    <licenseUrl>https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt</licenseUrl>
+    <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
@@ -20,5 +20,7 @@
     <file src="Microsoft.ChakraCore.X64.props" target="build" />
 
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native\ChakraCore.dll" />
+
+    <file src="..\..\LICENSE.txt" target="" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.X86.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.X86.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>Chakra Team</authors>
     <owners>Chakra Team</owners>
-    <licenseUrl>https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt</licenseUrl>
+    <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
@@ -20,5 +20,7 @@
     <file src="Microsoft.ChakraCore.X86.props" target="build" />
 
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native\ChakraCore.dll" />
+
+    <file src="..\..\LICENSE.txt" target="" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Chakra Team</owners>
-    <licenseUrl>https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt</licenseUrl>
+    <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
@@ -22,5 +22,7 @@
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native\ChakraCore.dll" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native\ChakraCore.dll" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native\ChakraCore.dll" />
+
+    <file src="..\..\LICENSE.txt" target="" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.vc140.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.vc140.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Chakra Team</owners>
-    <licenseUrl>https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt</licenseUrl>
+    <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
@@ -66,5 +66,7 @@
     <file src="..\VcBuild\bin\arm_release\ChakraCore.pdb" target="lib\native\v140\arm\debug\ChakraCore.pdb" />
     <file src="..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\debug\ch.exe" />
     <file src="..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\debug\ch.pdb" />
+
+    <file src="..\..\LICENSE.txt" target="" />
   </files>
 </package>


### PR DESCRIPTION
Currently, when building NuGet packages, the following warning is issued: “WARNING: NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.”. To solve this problem, it is necessary to replace the `licenseUrl` element by the `license` element.

This PR relates to issue #6572.