### PR TITLE
NuGet: Add to MSBuild scripts a ability to deploy an `win-arm` assembly for the `AnyCPU` target

### DIFF
--- a/Build/NuGet/Microsoft.ChakraCore.Symbols.props
+++ b/Build/NuGet/Microsoft.ChakraCore.Symbols.props
@@ -11,6 +11,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*">
+      <Link>arm\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
   </ItemGroup>
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config')) And '$(Platform)' == 'x86'">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*">

--- a/Build/NuGet/Microsoft.ChakraCore.props
+++ b/Build/NuGet/Microsoft.ChakraCore.props
@@ -11,6 +11,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*">
+      <Link>arm\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
   </ItemGroup>
   <ItemGroup Condition=" (Exists('packages.config') Or Exists('packages.$(MSBuildProjectName).config') Or Exists('project.json') Or Exists('project.$(MSBuildProjectName).json')) And '$(Platform)' == 'x86'">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*">


### PR DESCRIPTION
In .NET Framework projects with installed the Microsoft.ChakraCore package, during compilation for the `AnyCPU` target platform, MSBuild script creates two subdirectories (`x86` and `x64`) in the `bin\[Debug|Release]` directory, into which it copies the corresponding assemblies. In my opinion, it is worth implementing a similar functionality for Windows (ARM) assembly.

This PR relates to issue #6572.