### PR TITLE
NuGet: Add a replacement tokens to the `.nuspec` files

### DIFF
--- a/Build/NuGet/Microsoft.ChakraCore.ARM.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.ARM.nuspec
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.ARM</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Chakra Team</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
+    <authors>$authors$</authors>
+    <owners>$owners$</owners>
+    <license type="file">$licenseFile$</license>
+    <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>Copyright (C) 2016 Microsoft</copyright>
+    <description>$defaultDescription$</description>
+    <releaseNotes>$defaultReleaseNotes$</releaseNotes>
+    <copyright>$copyright$</copyright>
     <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <tags>$commonTags$</tags>
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.ARM.props" target="build" />
+    <file src="$id$.props" target="build" />
 
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native\ChakraCore.dll" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    <file src="..\..\LICENSE.txt" target="$licenseFile$" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.Symbols.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.Symbols.nuspec
@@ -1,28 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.Symbols</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Chakra Team</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
+    <authors>$authors$</authors>
+    <owners>$owners$</owners>
+    <license type="file">$licenseFile$</license>
+    <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>Copyright (C) 2016 Microsoft</copyright>
+    <description>$defaultDescription$</description>
+    <releaseNotes>$defaultReleaseNotes$</releaseNotes>
+    <copyright>$copyright$</copyright>
     <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <tags>$commonTags$</tags>
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.Shared.props" target="build\Microsoft.ChakraCore.Symbols.props" />
+    <file src="Microsoft.ChakraCore.Shared.props" target="build\$id$.props" />
 
     <file src="..\VcBuild\bin\x86_release\ChakraCore.pdb" target="runtimes\win7-x86\native\ChakraCore.pdb" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.pdb" target="runtimes\win7-x64\native\ChakraCore.pdb" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.pdb" target="runtimes\win8-arm\native\ChakraCore.pdb" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    <file src="..\..\LICENSE.txt" target="$licenseFile$" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.X64.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.X64.nuspec
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.X64</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Chakra Team</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
+    <authors>$authors$</authors>
+    <owners>$owners$</owners>
+    <license type="file">$licenseFile$</license>
+    <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>Copyright (C) 2016 Microsoft</copyright>
+    <description>$defaultDescription$</description>
+    <releaseNotes>$defaultReleaseNotes$</releaseNotes>
+    <copyright>$copyright$</copyright>
     <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <tags>$commonTags$</tags>
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.X64.props" target="build" />
+    <file src="$id$.props" target="build" />
 
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native\ChakraCore.dll" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    <file src="..\..\LICENSE.txt" target="$licenseFile$" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.X86.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.X86.nuspec
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.X86</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Chakra Team</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
+    <authors>$authors$</authors>
+    <owners>$owners$</owners>
+    <license type="file">$licenseFile$</license>
+    <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>Copyright (C) 2016 Microsoft</copyright>
+    <description>$defaultDescription$</description>
+    <releaseNotes>$defaultReleaseNotes$</releaseNotes>
+    <copyright>$copyright$</copyright>
     <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <tags>$commonTags$</tags>
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.X86.props" target="build" />
+    <file src="$id$.props" target="build" />
 
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native\ChakraCore.dll" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    <file src="..\..\LICENSE.txt" target="$licenseFile$" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.nuspec
@@ -1,28 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata minClientVersion="3.4">
-    <id>Microsoft.ChakraCore</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Microsoft</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
+    <authors>$authors$</authors>
+    <owners>$owners$</owners>
+    <license type="file">$licenseFile$</license>
+    <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <description>$defaultDescription$</description>
+    <releaseNotes>$defaultReleaseNotes$</releaseNotes>
+    <copyright>$copyright$</copyright>
     <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <tags>$commonTags$</tags>
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.Shared.props" target="build\Microsoft.ChakraCore.props" />
+    <file src="Microsoft.ChakraCore.Shared.props" target="build\$id$.props" />
 
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native\ChakraCore.dll" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native\ChakraCore.dll" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native\ChakraCore.dll" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    <file src="..\..\LICENSE.txt" target="$licenseFile$" />
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.vc140.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.vc140.nuspec
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.vc140</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Microsoft</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
+    <authors>$authors$</authors>
+    <owners>$owners$</owners>
+    <license type="file">$licenseFile$</license>
+    <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <description>$defaultDescription$</description>
+    <releaseNotes>$defaultReleaseNotes$</releaseNotes>
+    <copyright>$copyright$</copyright>
     <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native,nativepackage,C++,vc140</tags>
+    <tags>$commonTags$,nativepackage,C++,vc140</tags>
   </metadata>
   <files>
     <!--Build-->
-    <file src="Microsoft.ChakraCore.vc140.targets" target="build\native"/>
+    <file src="$id$.targets" target="build\native"/>
 
     <!--Include-->
     <file src="..\..\lib\Jsrt\ChakraCommon.h" target="build\native\include\ChakraCommon.h"/>
@@ -67,6 +66,6 @@
     <file src="..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\debug\ch.exe" />
     <file src="..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\debug\ch.pdb" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    <file src="..\..\LICENSE.txt" target="$licenseFile$" />
   </files>
 </package>

--- a/Build/NuGet/package-common-properties.xml
+++ b/Build/NuGet/package-common-properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<properties>
+  <authors>Microsoft</authors>
+  <owners>Chakra Team</owners>
+  <licenseFile>LICENSE.txt</licenseFile>
+  <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
+  <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+  <defaultDescription>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</defaultDescription>
+  <defaultReleaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</defaultReleaseNotes>
+  <commonTags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</commonTags>
+</properties>

--- a/Build/NuGet/package.ps1
+++ b/Build/NuGet/package.ps1
@@ -1,34 +1,72 @@
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
+# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
-$root = (split-path -parent $MyInvocation.MyCommand.Definition) + '\..'
+using namespace System.Collections
+using namespace System.IO
+using namespace System.Text
 
-$packageRoot = "$root\NuGet"
-$packageVersionFile = "$packageRoot\.pack-version"
-$packageArtifacts = "$packageRoot\Artifacts"
-$targetNugetExe = "$packageRoot\nuget.exe"
+$packageRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$packageVersionFile = Join-Path $packageRoot '.pack-version'
+$packageСommonPropertiesFile = Join-Path $packageRoot 'package-common-properties.xml'
+$packageArtifactsDir = Join-Path $packageRoot 'Artifacts'
+$localNugetExe = Join-Path $packageRoot 'nuget.exe'
 
-If (Test-Path $packageArtifacts)
-{
+# helper for getting properties that are common to all packages
+function GetPackageCommonProperties() {
+    $version = (Get-Content $packageVersionFile)
+    $commonPropertiesXml = [xml](Get-Content $packageСommonPropertiesFile -Encoding utf8)
+
+    $commonProperties = @{ version = $version }
+
+    foreach ($propertyElem in $commonPropertiesXml.DocumentElement.SelectNodes('child::*')) {
+        $commonProperties.Add($propertyElem.Name, $propertyElem.'#text')
+    }
+
+    return $commonProperties;
+}
+
+# helper to create NuGet package
+function CreateNugetPackage ([string]$nuspecFile, [Hashtable]$commonProperties) {
+    $id = [Path]::GetFileNameWithoutExtension($packageNuspecFile)
+    $properties = @{ id = $id }
+    $properties += $commonProperties
+
+    $sb = New-Object StringBuilder
+
+    foreach ($propertyName in $properties.Keys){
+        $propertyValue = $properties[$propertyName]
+
+        if ($sb.Length -gt 0) {
+            [void]$sb.Append(';');
+        }
+        [void]$sb.AppendFormat('{0}={1}', $propertyName, $propertyValue.Replace('"', '""'));
+    }
+
+    $propertiesStr = $sb.toString()
+    [void]$sb.Clear()
+
+    & $localNugetExe pack $nuspecFile -OutputDirectory $packageArtifactsDir -Properties $propertiesStr
+}
+
+if (Test-Path $packageArtifactsDir) {
     # Delete any existing output.
-    Remove-Item $packageArtifacts\*.nupkg
+    Remove-Item "$packageArtifactsDir\*.nupkg"
 }
 
-If (!(Test-Path $targetNugetExe))
-{
-    $sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+if (!(Test-Path $localNugetExe)) {
+    $nugetDistUrl = 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe'
 
-    Write-Host "NuGet.exe not found - downloading latest from $sourceNugetExe"
+    Write-Host "NuGet.exe not found - downloading latest from $nugetDistUrl"
 
-    Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
+    Invoke-WebRequest $nugetDistUrl -OutFile $localNugetExe
 }
 
-$versionStr = (Get-Content $packageVersionFile) 
+$packageCommonProperties = GetPackageCommonProperties
 
 # Create new packages for any nuspec files that exist in this directory.
-Foreach ($nuspec in $(Get-Item $packageRoot\*.nuspec))
-{
-    & $targetNugetExe pack $nuspec -outputdirectory $packageArtifacts -properties version=$versionStr
+foreach ($packageNuspecFile in $(Get-Item "$packageRoot\*.nuspec")) {
+    CreateNugetPackage $packageNuspecFile $packageCommonProperties
 }


### PR DESCRIPTION
As a first step to reduce duplication in the source code of NuGet packages, I started by adding replacement tokens to the `.nuspec` files (`$replacementToken$`). These tokens are used to substitute values for common properties of packages. I use an XML file (`package-common-properties.xml`) to store the common properties of packages. In the beginning, I wanted to use a JSON file, but then I decided that XML format is more consistent with overall style of the ChakraCore project. The `.pack-version` file is still used to store a version number of packages, because it is used in the [`check_copyright.sh`](https://github.com/chakra-core/ChakraCore/blob/3b3aa9ba1ddca0fc2f29681fe78d83aa580aaa1d/jenkins/check_copyright.sh) script. In the future, `version` property can be moved to the `package-common-properties.xml` file.

I also plan two more steps to reduce duplication:
 1. Implement a `.nuspec` file inheritance in order to move common elements into one base `.nuspec` file.
 1. Start creating packages based on the package list that stored in the XML file. Also at this step, I plan to create a MSBuild and PowerShell script templates for platform-specific packages. In these templates I plan to using a primitive [Mustache](http://mustache.github.io/) style syntax.

This PR relates to issue #6586.