### PR TITLE
NuGet: Add a replacement tokens to the `.nuspec` files (alternative version)

### DIFF
--- a/Build/NuGet/Microsoft.ChakraCore.ARM.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.ARM.nuspec
@@ -1,26 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.ARM</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Chakra Team</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>Copyright (C) 2016 Microsoft</copyright>
-    <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <description>$description$</description>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$</tags>
+    $CommonMetadataElements$
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.ARM.props" target="build" />
+    <file src="$id$.props" target="build" />
 
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native\ChakraCore.dll" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    $CommonFileElements$
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.Symbols.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.Symbols.nuspec
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.Symbols</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Chakra Team</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>Copyright (C) 2016 Microsoft</copyright>
-    <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <description>$description$</description>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$</tags>
+    $CommonMetadataElements$
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.Shared.props" target="build\Microsoft.ChakraCore.Symbols.props" />
+    <file src="Microsoft.ChakraCore.Shared.props" target="build\$id$.props" />
 
     <file src="..\VcBuild\bin\x86_release\ChakraCore.pdb" target="runtimes\win7-x86\native\ChakraCore.pdb" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.pdb" target="runtimes\win7-x64\native\ChakraCore.pdb" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.pdb" target="runtimes\win8-arm\native\ChakraCore.pdb" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    $CommonFileElements$
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.X64.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.X64.nuspec
@@ -1,26 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.X64</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Chakra Team</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>Copyright (C) 2016 Microsoft</copyright>
-    <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <description>$description$</description>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$</tags>
+    $CommonMetadataElements$
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.X64.props" target="build" />
+    <file src="$id$.props" target="build" />
 
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native\ChakraCore.dll" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    $CommonFileElements$
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.X86.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.X86.nuspec
@@ -1,26 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.X86</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Chakra Team</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>Copyright (C) 2016 Microsoft</copyright>
-    <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <description>$description$</description>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$</tags>
+    $CommonMetadataElements$
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.X86.props" target="build" />
+    <file src="$id$.props" target="build" />
 
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native\ChakraCore.dll" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    $CommonFileElements$
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.nuspec
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata minClientVersion="3.4">
-    <id>Microsoft.ChakraCore</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Microsoft</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+    <description>$description$</description>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$</tags>
+    $CommonMetadataElements$
   </metadata>
   <files>
-    <file src="Microsoft.ChakraCore.Shared.props" target="build\Microsoft.ChakraCore.props" />
+    <file src="Microsoft.ChakraCore.Shared.props" target="build\$id$.props" />
 
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native\ChakraCore.dll" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native\ChakraCore.dll" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native\ChakraCore.dll" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    $CommonFileElements$
   </files>
 </package>

--- a/Build/NuGet/Microsoft.ChakraCore.vc140.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.vc140.nuspec
@@ -1,24 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.vc140</id>
-    <!-- Note: actual version number is overridden by the NuGet package creation command. -->
+    <id>$id$</id>
     <version>$version$</version>
-    <authors>Microsoft</authors>
-    <owners>Chakra Team</owners>
-    <license type="file">LICENSE.txt</license>
-    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <developmentDependency>true</developmentDependency>
-    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
-    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <language>en-US</language>
-    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native,nativepackage,C++,vc140</tags>
+    <description>$description$</description>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$,nativepackage,C++,vc140</tags>
+    $CommonMetadataElements$
   </metadata>
   <files>
     <!--Build-->
-    <file src="Microsoft.ChakraCore.vc140.targets" target="build\native"/>
+    <file src="$id$.targets" target="build\native"/>
 
     <!--Include-->
     <file src="..\..\lib\Jsrt\ChakraCommon.h" target="build\native\include\ChakraCommon.h"/>
@@ -67,6 +59,6 @@
     <file src="..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\debug\ch.exe" />
     <file src="..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\debug\ch.pdb" />
 
-    <file src="..\..\LICENSE.txt" target="" />
+    $CommonFileElements$
   </files>
 </package>

--- a/Build/NuGet/package-common-properties.xml
+++ b/Build/NuGet/package-common-properties.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<commonProperties>
+  <defaultProperties>
+    <!--
+      Custom properties whose values are used to replace $-delimited tokens (for example, `$description$`)
+      in the `.nuspec` files. For naming these properties, it is recommended to use the camelCase style.
+    -->
+    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
+    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
+    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
+  </defaultProperties>
+  <!--
+    XML content of the following two elements is substituted into a `$CommonMetadataElements$` and
+    `$CommonFileElements$` tokens in the `.nuspec` files. This XML content is completely static and
+    cannot contain $-delimited tokens.
+  -->
+  <commonMetadataElements>
+    <authors>Microsoft</authors>
+    <owners>Chakra Team</owners>
+    <license type="file">LICENSE.txt</license>
+    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <developmentDependency>true</developmentDependency>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <language>en-US</language>
+  </commonMetadataElements>
+  <commonFileElements>
+    <file src="..\..\LICENSE.txt" target="" />
+  </commonFileElements>
+</commonProperties>

--- a/Build/NuGet/package.ps1
+++ b/Build/NuGet/package.ps1
@@ -1,34 +1,77 @@
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
+# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
-$root = (split-path -parent $MyInvocation.MyCommand.Definition) + '\..'
+using namespace System.Collections
+using namespace System.IO
+using namespace System.Text
 
-$packageRoot = "$root\NuGet"
-$packageVersionFile = "$packageRoot\.pack-version"
-$packageArtifacts = "$packageRoot\Artifacts"
-$targetNugetExe = "$packageRoot\nuget.exe"
+$packageRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$packageVersionFile = Join-Path $packageRoot '.pack-version'
+$packageСommonPropertiesFile = Join-Path $packageRoot 'package-common-properties.xml'
+$packageArtifactsDir = Join-Path $packageRoot 'Artifacts'
+$localNugetExe = Join-Path $packageRoot 'nuget.exe'
 
-If (Test-Path $packageArtifacts)
-{
+# helper for getting properties that are common to all packages
+function GetPackageCommonProperties() {
+    $version = (Get-Content $packageVersionFile)
+    $commonPropertiesXml = [xml](Get-Content $packageСommonPropertiesFile -Encoding utf8)
+    $rootElem = $commonPropertiesXml.DocumentElement
+
+    $commonProperties = @{
+        version = $version;
+        CommonMetadataElements = $rootElem.commonMetadataElements.InnerXml;
+        CommonFileElements = $rootElem.commonFileElements.InnerXml
+    }
+
+    foreach ($propertyElem in $rootElem.defaultProperties.SelectNodes('child::*')) {
+        $commonProperties.Add($propertyElem.Name, $propertyElem.'#text')
+    }
+
+    return $commonProperties;
+}
+
+# helper to create NuGet package
+function CreateNugetPackage ([string]$nuspecFile, [Hashtable]$commonProperties) {
+    $id = [Path]::GetFileNameWithoutExtension($packageNuspecFile)
+    $properties = @{ id = $id }
+    $properties += $commonProperties
+
+    $sb = New-Object StringBuilder
+
+    foreach ($propertyName in $properties.Keys){
+        $propertyValue = $properties[$propertyName]
+
+        if ($sb.Length -gt 0) {
+            [void]$sb.Append(';');
+        }
+        [void]$sb.AppendFormat('{0}={1}', $propertyName, $propertyValue.Replace('"', '""'));
+    }
+
+    $propertiesStr = $sb.toString()
+    [void]$sb.Clear()
+
+    & $localNugetExe pack $nuspecFile -OutputDirectory $packageArtifactsDir -Properties $propertiesStr
+}
+
+if (Test-Path $packageArtifactsDir) {
     # Delete any existing output.
-    Remove-Item $packageArtifacts\*.nupkg
+    Remove-Item "$packageArtifactsDir\*.nupkg"
 }
 
-If (!(Test-Path $targetNugetExe))
-{
-    $sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+if (!(Test-Path $localNugetExe)) {
+    $nugetDistUrl = 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe'
 
-    Write-Host "NuGet.exe not found - downloading latest from $sourceNugetExe"
+    Write-Host "NuGet.exe not found - downloading latest from $nugetDistUrl"
 
-    Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
+    Invoke-WebRequest $nugetDistUrl -OutFile $localNugetExe
 }
 
-$versionStr = (Get-Content $packageVersionFile) 
+$packageCommonProperties = GetPackageCommonProperties
 
 # Create new packages for any nuspec files that exist in this directory.
-Foreach ($nuspec in $(Get-Item $packageRoot\*.nuspec))
-{
-    & $targetNugetExe pack $nuspec -outputdirectory $packageArtifacts -properties version=$versionStr
+foreach ($packageNuspecFile in $(Get-Item "$packageRoot\*.nuspec")) {
+    CreateNugetPackage $packageNuspecFile $packageCommonProperties
 }


### PR DESCRIPTION
**Note:** Main difference from [previous version of this pull request](https://github.com/chakra-core/ChakraCore/pull/6606) is more advanced usage of $-delimited tokens.

As a first step to reduce duplication in the source code of NuGet packages, I started by adding [replacement tokens](https://docs.microsoft.com/en-us/nuget/reference/nuspec#replacement-tokens) to the `.nuspec` files (`$replacementToken$`). These tokens are used to substitute values for common properties of packages. I use an XML file (`package-common-properties.xml`) to store the common properties of packages. The `.pack-version` file is still used to store a version number of packages, because it is used in the [`check_copyright.sh`](https://github.com/chakra-core/ChakraCore/blob/3b3aa9ba1ddca0fc2f29681fe78d83aa580aaa1d/jenkins/check_copyright.sh) script. In the future, `version` property can be moved to the `package-common-properties.xml` file.

In the `package-common-properties.xml` file stores two group of properties: properties containing values of primitive types and properties containing chunks of XML code.

First group is called the default properties and contains values to be substituted into elements and attributes of the `.nuspec` file:

```xml
<?xml version="1.0" encoding="utf-8"?>
<commonProperties>
  <defaultProperties>
    …
    <description>ChakraCore is the core part of the Chakra Javascript engine that powers Microsoft Edge.</description>
    <releaseNotes>https://github.com/Microsoft/ChakraCore/wiki/Roadmap#release-notes</releaseNotes>
    <tags>Chakra,ChakraCore,javascript,js,ecmascript,compiler,platform,oss,opensource,native</tags>
  </defaultProperties>
  …
</commonProperties>
```
These properties are custom and new ones can be added to them later. For naming these properties, it is recommended to use the camelCase style. It is assumed that in the future, values of these properties will be overridden by specific packages (when an XML file containing a list of packages appears).

Second group of properties is called the common elements and contains XML elements that will be substituted into the `.nuspec` file:

```xml
<?xml version="1.0" encoding="utf-8"?>
<commonProperties>
  ...
  <commonMetadataElements>
    <authors>Microsoft</authors>
    <owners>Chakra Team</owners>
    <license type="file">LICENSE.txt</license>
    <projectUrl>https://github.com/Microsoft/ChakraCore</projectUrl>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <developmentDependency>true</developmentDependency>
    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
    <language>en-US</language>
  </commonMetadataElements>
  <commonFileElements>
    <file src="..\..\LICENSE.txt" target="" />
  </commonFileElements>
</commonProperties>
```
XML content of these properties is substituted into a `$CommonMetadataElements$` and `$CommonFileElements$` tokens in the `.nuspec` files. This XML content is completely static and cannot contain $-delimited tokens. This feature is [not described in the official documentation](https://github.com/NuGet/Home/issues/9153) and is mainly used inside Microsoft (for example, in the [Arcade](https://github.com/dotnet/arcade) and [Source Link](https://github.com/dotnet/sourcelink) projects). Using this feature is more preferable than implementing inheritance of the `.nuspec` files yourself.

In the second step, I plan to start creating packages based on the package list that stored in the XML file. Also at this step, I plan to create a MSBuild and PowerShell script templates for platform-specific packages. In these templates I plan to using a primitive [Mustache](http://mustache.github.io/) style syntax.

This PR relates to issue #6586.