### PR TITLE
Remove non-standard IE behaviour from Error constructor 

### DIFF
--- a/test/Debugger/JsrtDebugUtilsAddPropertyType.js.dbg.baseline
+++ b/test/Debugger/JsrtDebugUtilsAddPropertyType.js.dbg.baseline
@@ -74,7 +74,6 @@
         },
         "a20": {
           "#__proto__": "Object {...}",
-          "description": "string Hello World!",
           "message": "string Hello World!",
           "stack": "string <large string>"
         },

--- a/test/DebuggerCommon/ES6_letconst_trycatch_simple_fast.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_letconst_trycatch_simple_fast.js.dbg.baseline
@@ -41,8 +41,6 @@
     "locals": {
       "e": {
         "#__proto__": "Object {...}",
-        "number": "number 0",
-        "description": "string ",
         "stack": "string <large string>"
       },
       "z": "number 2"

--- a/test/DebuggerCommon/attachWithDeferParse.js.dbg.baseline
+++ b/test/DebuggerCommon/attachWithDeferParse.js.dbg.baseline
@@ -77,7 +77,6 @@
       "t": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       },

--- a/test/DebuggerCommon/bug_507528.js
+++ b/test/DebuggerCommon/bug_507528.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -24,5 +25,5 @@ try
 }
 catch(e)
 {
-    WScript.Echo(e.description);
+    WScript.Echo(e.message);
 }

--- a/test/DebuggerCommon/bug_543550.js.dbg.baseline
+++ b/test/DebuggerCommon/bug_543550.js.dbg.baseline
@@ -56,7 +56,6 @@
         "size": {
           "#__proto__": "Object {...}",
           "message": "string Map.prototype.size: 'this' is not a Map object",
-          "description": "string Map.prototype.size: 'this' is not a Map object",
           "number": "number -2146823172",
           "stack": "string TypeError: Map.prototype.size: 'this' is not a Map object\n\tat Global code (bug_543550.js:8:1)"
         },

--- a/test/DebuggerCommon/catchInspection.js.dbg.baseline
+++ b/test/DebuggerCommon/catchInspection.js.dbg.baseline
@@ -132,7 +132,6 @@
       "e": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       },
@@ -232,7 +231,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       }
@@ -284,7 +282,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       },
@@ -337,7 +334,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       },
@@ -390,7 +386,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       }
@@ -439,7 +434,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       }
@@ -488,7 +482,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       }
@@ -537,7 +530,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       },
@@ -581,7 +573,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       },
@@ -708,7 +699,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       }
@@ -719,7 +709,6 @@
       "ex": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       }

--- a/test/DebuggerCommon/globalFuncVars.js.dbg.baseline
+++ b/test/DebuggerCommon/globalFuncVars.js.dbg.baseline
@@ -62,7 +62,6 @@
       "ex1": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       }
@@ -136,7 +135,6 @@
       "ex2": {
         "#__proto__": "Object {...}",
         "message": "string <large string>",
-        "description": "string <large string>",
         "number": "number -2146823279",
         "stack": "string <large string>"
       },

--- a/test/DebuggerCommon/indexprop.js.dbg.baseline
+++ b/test/DebuggerCommon/indexprop.js.dbg.baseline
@@ -99,7 +99,6 @@
         },
         "[4]": {
           "#__proto__": "Object {...}",
-          "description": "string ErrorObj",
           "message": "string ErrorObj",
           "stack": "string <large string>",
           "[105]": "string 105"

--- a/test/DebuggerCommon/step_out_from_catch_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/step_out_from_catch_attach.js.dbg.baseline
@@ -16,8 +16,6 @@
       "x": "number 1",
       "e": {
         "#__proto__": "Object {...}",
-        "number": "number 0",
-        "description": "string ",
         "stack": "string <large string>"
       },
       "z": "number 1"

--- a/test/Error/errorCtor.js
+++ b/test/Error/errorCtor.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -50,7 +51,6 @@ function DumpObject(e)
     {
         a[a.length] = i;
     }
-    a[a.length] = "description"; // Explicitly adding the known non-enumerable members
     a[a.length] = "number";
     a[a.length] = "stack";
     a.sort();

--- a/test/Error/errorCtor_v4.baseline
+++ b/test/Error/errorCtor_v4.baseline
@@ -2,8 +2,7 @@
 Error()
 message      =             (string)
 name         = Error       (string)
-description  =             (string)
-number       = 0           (number)
+number       = undefined   (undefined)
 stack        = Error
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -13,8 +12,7 @@ stack        = Error
 Error(NaN, NaN)
 message      = NaN         (string)
 name         = Error       (string)
-description  = NaN         (string)
-number       = NaN         (number)
+number       = undefined   (undefined)
 stack        = Error: NaN
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -24,8 +22,7 @@ stack        = Error: NaN
 Error(1, 1)
 message      = 1           (string)
 name         = Error       (string)
-description  = 1           (string)
-number       = 1           (number)
+number       = undefined   (undefined)
 stack        = Error: 1
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -35,8 +32,7 @@ stack        = Error: 1
 Error(1.1, 1.1)
 message      = 1.1         (string)
 name         = Error       (string)
-description  = 1.1         (string)
-number       = 1.1         (number)
+number       = undefined   (undefined)
 stack        = Error: 1.1
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -46,8 +42,7 @@ stack        = Error: 1.1
 Error(undefined, undefined)
 message      =             (string)
 name         = Error       (string)
-description  = undefined   (string)
-number       = NaN         (number)
+number       = undefined   (undefined)
 stack        = Error
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -57,8 +52,7 @@ stack        = Error
 Error(null, null)
 message      = null        (string)
 name         = Error       (string)
-description  = null        (string)
-number       = 0           (number)
+number       = undefined   (undefined)
 stack        = Error: null
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -68,8 +62,7 @@ stack        = Error: null
 Error(true, true)
 message      = true        (string)
 name         = Error       (string)
-description  = true        (string)
-number       = 1           (number)
+number       = undefined   (undefined)
 stack        = Error: true
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -79,8 +72,7 @@ stack        = Error: true
 Error(false, false)
 message      = false       (string)
 name         = Error       (string)
-description  = false       (string)
-number       = 0           (number)
+number       = undefined   (undefined)
 stack        = Error: false
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -90,8 +82,7 @@ stack        = Error: false
 Error('blah', 'blah')
 message      = blah        (string)
 name         = Error       (string)
-description  = blah        (string)
-number       = NaN         (number)
+number       = undefined   (undefined)
 stack        = Error: blah
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -101,8 +92,7 @@ stack        = Error: blah
 Error(new Object(), new Object())
 message      = [object Object](string)
 name         = Error       (string)
-description  = [object Object](string)
-number       = NaN         (number)
+number       = undefined   (undefined)
 stack        = Error: [object Object]
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -112,8 +102,7 @@ stack        = Error: [object Object]
 Error(new String('blah'), new String('blah'))
 message      = blah        (string)
 name         = Error       (string)
-description  = blah        (string)
-number       = NaN         (number)
+number       = undefined   (undefined)
 stack        = Error: blah
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -123,8 +112,7 @@ stack        = Error: blah
 Error(new Number(1.1), new Number(1.1))
 message      = 1.1         (string)
 name         = Error       (string)
-description  = 1.1         (string)
-number       = 1.1         (number)
+number       = undefined   (undefined)
 stack        = Error: 1.1
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -134,8 +122,7 @@ stack        = Error: 1.1
 Error(new Boolean(true), new Boolean(true))
 message      = true        (string)
 name         = Error       (string)
-description  = true        (string)
-number       = 1           (number)
+number       = undefined   (undefined)
 stack        = Error: true
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -143,28 +130,21 @@ stack        = Error: true
    at Global code (errorCtor.js:111:1)(string)
 -----------------------------------------
 Error(Test, Test)
-message      = function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
+message      = function Test(typename, s)
+{
+    WScript.Echo("-----------------------------------------");
+    WScript.Echo(typename + "(" + s + ")");
+    var e = eval("new " + typename + "(" + s + ")");
+    DumpObject(e);
 }(string)
 name         = Error       (string)
-description  = function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
-}(string)
-number       = NaN         (number)
-stack        = Error: function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
+number       = undefined   (undefined)
+stack        = Error: function Test(typename, s)
+{
+    WScript.Echo("-----------------------------------------");
+    WScript.Echo(typename + "(" + s + ")");
+    var e = eval("new " + typename + "(" + s + ")");
+    DumpObject(e);
 }
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -174,7 +154,6 @@ stack        = Error: function Test(typename, s)
 Error(NaN)
 message      = NaN         (string)
 name         = Error       (string)
-description  = NaN         (string)
 number       = undefined   (undefined)
 stack        = Error: NaN
    at eval code (eval code:1:1)
@@ -185,7 +164,6 @@ stack        = Error: NaN
 Error(1)
 message      = 1           (string)
 name         = Error       (string)
-description  = 1           (string)
 number       = undefined   (undefined)
 stack        = Error: 1
    at eval code (eval code:1:1)
@@ -196,7 +174,6 @@ stack        = Error: 1
 Error(undefined)
 message      =             (string)
 name         = Error       (string)
-description  = undefined   (string)
 number       = undefined   (undefined)
 stack        = Error
    at eval code (eval code:1:1)
@@ -207,7 +184,6 @@ stack        = Error
 Error(null)
 message      = null        (string)
 name         = Error       (string)
-description  = null        (string)
 number       = undefined   (undefined)
 stack        = Error: null
    at eval code (eval code:1:1)
@@ -218,7 +194,6 @@ stack        = Error: null
 Error(true)
 message      = true        (string)
 name         = Error       (string)
-description  = true        (string)
 number       = undefined   (undefined)
 stack        = Error: true
    at eval code (eval code:1:1)
@@ -229,7 +204,6 @@ stack        = Error: true
 Error(false)
 message      = false       (string)
 name         = Error       (string)
-description  = false       (string)
 number       = undefined   (undefined)
 stack        = Error: false
    at eval code (eval code:1:1)
@@ -240,7 +214,6 @@ stack        = Error: false
 Error('blah')
 message      = blah        (string)
 name         = Error       (string)
-description  = blah        (string)
 number       = undefined   (undefined)
 stack        = Error: blah
    at eval code (eval code:1:1)
@@ -251,7 +224,6 @@ stack        = Error: blah
 Error(new Object())
 message      = [object Object](string)
 name         = Error       (string)
-description  = [object Object](string)
 number       = undefined   (undefined)
 stack        = Error: [object Object]
    at eval code (eval code:1:1)
@@ -262,7 +234,6 @@ stack        = Error: [object Object]
 Error(new String('blah'))
 message      = blah        (string)
 name         = Error       (string)
-description  = blah        (string)
 number       = undefined   (undefined)
 stack        = Error: blah
    at eval code (eval code:1:1)
@@ -273,7 +244,6 @@ stack        = Error: blah
 Error(new Number(1.1))
 message      = 1.1         (string)
 name         = Error       (string)
-description  = 1.1         (string)
 number       = undefined   (undefined)
 stack        = Error: 1.1
    at eval code (eval code:1:1)
@@ -284,7 +254,6 @@ stack        = Error: 1.1
 Error(new Boolean(1.1))
 message      = true        (string)
 name         = Error       (string)
-description  = true        (string)
 number       = undefined   (undefined)
 stack        = Error: true
    at eval code (eval code:1:1)
@@ -293,28 +262,21 @@ stack        = Error: true
    at Global code (errorCtor.js:111:1)(string)
 -----------------------------------------
 Error(Test)
-message      = function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
+message      = function Test(typename, s)
+{
+    WScript.Echo("-----------------------------------------");
+    WScript.Echo(typename + "(" + s + ")");
+    var e = eval("new " + typename + "(" + s + ")");
+    DumpObject(e);
 }(string)
 name         = Error       (string)
-description  = function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
-}(string)
 number       = undefined   (undefined)
-stack        = Error: function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
+stack        = Error: function Test(typename, s)
+{
+    WScript.Echo("-----------------------------------------");
+    WScript.Echo(typename + "(" + s + ")");
+    var e = eval("new " + typename + "(" + s + ")");
+    DumpObject(e);
 }
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -324,7 +286,6 @@ stack        = Error: function Test(typename, s)
 TypeError()
 message      =             (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError
    at eval code (eval code:1:1)
@@ -335,7 +296,6 @@ stack        = TypeError
 TypeError(NaN, NaN)
 message      = NaN         (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: NaN
    at eval code (eval code:1:1)
@@ -346,7 +306,6 @@ stack        = TypeError: NaN
 TypeError(1, 1)
 message      = 1           (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: 1
    at eval code (eval code:1:1)
@@ -357,7 +316,6 @@ stack        = TypeError: 1
 TypeError(1.1, 1.1)
 message      = 1.1         (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: 1.1
    at eval code (eval code:1:1)
@@ -368,7 +326,6 @@ stack        = TypeError: 1.1
 TypeError(undefined, undefined)
 message      =             (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError
    at eval code (eval code:1:1)
@@ -379,7 +336,6 @@ stack        = TypeError
 TypeError(null, null)
 message      = null        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: null
    at eval code (eval code:1:1)
@@ -390,7 +346,6 @@ stack        = TypeError: null
 TypeError(true, true)
 message      = true        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: true
    at eval code (eval code:1:1)
@@ -401,7 +356,6 @@ stack        = TypeError: true
 TypeError(false, false)
 message      = false       (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: false
    at eval code (eval code:1:1)
@@ -412,7 +366,6 @@ stack        = TypeError: false
 TypeError('blah', 'blah')
 message      = blah        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: blah
    at eval code (eval code:1:1)
@@ -423,7 +376,6 @@ stack        = TypeError: blah
 TypeError(new Object(), new Object())
 message      = [object Object](string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: [object Object]
    at eval code (eval code:1:1)
@@ -434,7 +386,6 @@ stack        = TypeError: [object Object]
 TypeError(new String('blah'), new String('blah'))
 message      = blah        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: blah
    at eval code (eval code:1:1)
@@ -445,7 +396,6 @@ stack        = TypeError: blah
 TypeError(new Number(1.1), new Number(1.1))
 message      = 1.1         (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: 1.1
    at eval code (eval code:1:1)
@@ -456,7 +406,6 @@ stack        = TypeError: 1.1
 TypeError(new Boolean(true), new Boolean(true))
 message      = true        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: true
    at eval code (eval code:1:1)
@@ -465,22 +414,21 @@ stack        = TypeError: true
    at Global code (errorCtor.js:112:1)(string)
 -----------------------------------------
 TypeError(Test, Test)
-message      = function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
+message      = function Test(typename, s)
+{
+    WScript.Echo("-----------------------------------------");
+    WScript.Echo(typename + "(" + s + ")");
+    var e = eval("new " + typename + "(" + s + ")");
+    DumpObject(e);
 }(string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
-stack        = TypeError: function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
+stack        = TypeError: function Test(typename, s)
+{
+    WScript.Echo("-----------------------------------------");
+    WScript.Echo(typename + "(" + s + ")");
+    var e = eval("new " + typename + "(" + s + ")");
+    DumpObject(e);
 }
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)
@@ -490,7 +438,6 @@ stack        = TypeError: function Test(typename, s)
 TypeError(NaN)
 message      = NaN         (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: NaN
    at eval code (eval code:1:1)
@@ -501,7 +448,6 @@ stack        = TypeError: NaN
 TypeError(1)
 message      = 1           (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: 1
    at eval code (eval code:1:1)
@@ -512,7 +458,6 @@ stack        = TypeError: 1
 TypeError(undefined)
 message      =             (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError
    at eval code (eval code:1:1)
@@ -523,7 +468,6 @@ stack        = TypeError
 TypeError(null)
 message      = null        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: null
    at eval code (eval code:1:1)
@@ -534,7 +478,6 @@ stack        = TypeError: null
 TypeError(true)
 message      = true        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: true
    at eval code (eval code:1:1)
@@ -545,7 +488,6 @@ stack        = TypeError: true
 TypeError(false)
 message      = false       (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: false
    at eval code (eval code:1:1)
@@ -556,7 +498,6 @@ stack        = TypeError: false
 TypeError('blah')
 message      = blah        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: blah
    at eval code (eval code:1:1)
@@ -567,7 +508,6 @@ stack        = TypeError: blah
 TypeError(new Object())
 message      = [object Object](string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: [object Object]
    at eval code (eval code:1:1)
@@ -578,7 +518,6 @@ stack        = TypeError: [object Object]
 TypeError(new String('blah'))
 message      = blah        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: blah
    at eval code (eval code:1:1)
@@ -589,7 +528,6 @@ stack        = TypeError: blah
 TypeError(new Number(1.1))
 message      = 1.1         (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: 1.1
    at eval code (eval code:1:1)
@@ -600,7 +538,6 @@ stack        = TypeError: 1.1
 TypeError(new Boolean(1.1))
 message      = true        (string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
 stack        = TypeError: true
    at eval code (eval code:1:1)
@@ -609,22 +546,21 @@ stack        = TypeError: true
    at Global code (errorCtor.js:112:1)(string)
 -----------------------------------------
 TypeError(Test)
-message      = function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
+message      = function Test(typename, s)
+{
+    WScript.Echo("-----------------------------------------");
+    WScript.Echo(typename + "(" + s + ")");
+    var e = eval("new " + typename + "(" + s + ")");
+    DumpObject(e);
 }(string)
 name         = TypeError   (string)
-description  = undefined   (undefined)
 number       = undefined   (undefined)
-stack        = TypeError: function Test(typename, s)
-{
-    WScript.Echo("-----------------------------------------");
-    WScript.Echo(typename + "(" + s + ")");
-    var e = eval("new " + typename + "(" + s + ")");
-    DumpObject(e);
+stack        = TypeError: function Test(typename, s)
+{
+    WScript.Echo("-----------------------------------------");
+    WScript.Echo(typename + "(" + s + ")");
+    var e = eval("new " + typename + "(" + s + ")");
+    DumpObject(e);
 }
    at eval code (eval code:1:1)
    at Test(string, string) (errorCtor.js:68:5)

--- a/test/Error/errorProps.js
+++ b/test/Error/errorProps.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -20,7 +21,6 @@ function test(y)
     showProperty("message", y);
     showProperty("stack", y); // Explicitly adding the known non-enumerable members
     showProperty("number", y);
-    showProperty("description", y);
     for (x in y)
     {
         showProperty(x, y);

--- a/test/Error/errorProps_v4.baseline
+++ b/test/Error/errorProps_v4.baseline
@@ -5,7 +5,6 @@ Error.prototype
     message	  isOwn = true	 value = 
     stack	  isOwn = false	 value = undefined
     number	  isOwn = false	 value = undefined
-    description	  isOwn = false	 value = undefined
 RangeError.prototype
   ToString = RangeError
   Properties = 
@@ -13,7 +12,6 @@ RangeError.prototype
     message	  isOwn = true	 value = 
     stack	  isOwn = false	 value = undefined
     number	  isOwn = false	 value = undefined
-    description	  isOwn = false	 value = undefined
 ConversionError.prototype
 ReferenceError: 'ConversionError' is not defined
 
@@ -24,7 +22,6 @@ Error
     message	  isOwn = false	 value = undefined
     stack	  isOwn = false	 value = undefined
     number	  isOwn = false	 value = undefined
-    description	  isOwn = false	 value = undefined
     stackTraceLimit	  isOwn = true	 value = 10
 
 new Error()
@@ -34,8 +31,7 @@ new Error()
     message	  isOwn = false	 value = 
     stack	  isOwn = true	 value = Error
 	at Global code (errorProps.js:55:1)
-    number	  isOwn = true	 value = 0
-    description	  isOwn = true	 value = 
+    number	  isOwn = false	 value = undefined
 
 new Error(undefined)
   ToString = Error
@@ -45,7 +41,6 @@ new Error(undefined)
     stack	  isOwn = true	 value = Error
 	at Global code (errorProps.js:59:1)
     number	  isOwn = false	 value = undefined
-    description	  isOwn = true	 value = undefined
 
 new Error(null)
   ToString = Error: null
@@ -55,7 +50,6 @@ new Error(null)
     stack	  isOwn = true	 value = Error: null
 	at Global code (errorProps.js:63:1)
     number	  isOwn = false	 value = undefined
-    description	  isOwn = true	 value = null
 
 new Error("Hello")
   ToString = Error: Hello
@@ -65,17 +59,15 @@ new Error("Hello")
     stack	  isOwn = true	 value = Error: Hello
 	at Global code (errorProps.js:67:1)
     number	  isOwn = false	 value = undefined
-    description	  isOwn = true	 value = Hello
 
 new Error(100, "With a number")
-  ToString = Error: With a number
+  ToString = Error: 100
   Properties = 
     name	  isOwn = false	 value = Error
-    message	  isOwn = true	 value = With a number
-    stack	  isOwn = true	 value = Error: With a number
+    message	  isOwn = true	 value = 100
+    stack	  isOwn = true	 value = Error: 100
 	at Global code (errorProps.js:71:1)
-    number	  isOwn = true	 value = 100
-    description	  isOwn = true	 value = With a number
+    number	  isOwn = false	 value = undefined
 
 new Error("Hello"); name=undefined
   ToString = Error: Hello
@@ -85,7 +77,6 @@ new Error("Hello"); name=undefined
     stack	  isOwn = true	 value = Error: Hello
 	at Global code (errorProps.js:75:1)
     number	  isOwn = false	 value = undefined
-    description	  isOwn = true	 value = Hello
     name	  isOwn = true	 value = undefined
 
 new ReferenceError("I'm a reference error")
@@ -96,7 +87,6 @@ new ReferenceError("I'm a reference error")
     stack	  isOwn = true	 value = ReferenceError: I'm a reference error
 	at Global code (errorProps.js:80:1)
     number	  isOwn = false	 value = undefined
-    description	  isOwn = false	 value = undefined
 ReferenceError: 'RegExpError' is not defined
 
 new TypeError()
@@ -107,7 +97,6 @@ new TypeError()
     stack	  isOwn = true	 value = TypeError
 	at Global code (errorProps.js:90:1)
     number	  isOwn = false	 value = undefined
-    description	  isOwn = false	 value = undefined
 
 new TypeError(undefined)
   ToString = TypeError
@@ -117,7 +106,6 @@ new TypeError(undefined)
     stack	  isOwn = true	 value = TypeError
 	at Global code (errorProps.js:94:1)
     number	  isOwn = false	 value = undefined
-    description	  isOwn = false	 value = undefined
 
 new TypeError(null)
   ToString = TypeError: null
@@ -127,7 +115,6 @@ new TypeError(null)
     stack	  isOwn = true	 value = TypeError: null
 	at Global code (errorProps.js:98:1)
     number	  isOwn = false	 value = undefined
-    description	  isOwn = false	 value = undefined
 
 new TypeError("With a undef name")
   ToString = Error: With a undef name
@@ -137,7 +124,6 @@ new TypeError("With a undef name")
     stack	  isOwn = true	 value = Error: With a undef name
 	at Global code (errorProps.js:103:1)
     number	  isOwn = false	 value = undefined
-    description	  isOwn = false	 value = undefined
     name	  isOwn = true	 value = undefined
 
 Runtime TypeError()
@@ -148,4 +134,3 @@ Runtime TypeError()
     stack	  isOwn = true	 value = ReferenceError: 'boo' is not defined
 	at Global code (errorProps.js:111:5)
     number	  isOwn = true	 value = -2146823279
-    description	  isOwn = true	 value = 'boo' is not defined

--- a/test/Error/outofmem.baseline
+++ b/test/Error/outofmem.baseline
@@ -1,4 +1,3 @@
 Error
 Out of memory
-Out of memory
 -2146828281

--- a/test/Error/outofmem.js
+++ b/test/Error/outofmem.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -14,7 +15,6 @@ catch (e)
 {
     WScript.Echo(e.name);
     WScript.Echo(e.message);
-    WScript.Echo(e.description);
     WScript.Echo(e.number);
 }
 

--- a/test/Regex/Bug1153694.js
+++ b/test/Regex/Bug1153694.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -10,7 +11,7 @@ try {
         }
     }
 } catch(e) {
-    var desc = e.description;
+    var desc = e.message;
     if(desc == "Invalid left-hand side in assignment.") 
     {
         WScript.Echo("Expected " + desc);

--- a/test/StackTrace/ErrorDotStackAlreadyExists.js
+++ b/test/StackTrace/ErrorDotStackAlreadyExists.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -7,7 +8,7 @@ try {
     var e = Error("123");
     e.somevalue = "xyz";
     e.stack = "abacaba";
-    WScript.Echo("description = " + e.description);
+    WScript.Echo("description = " + e.message);
     WScript.Echo("stack = " + e.stack);
     for (var p in e) {
         WScript.Echo(p + " = " + e[p]);
@@ -17,7 +18,7 @@ try {
 }
 catch (ex) {
     WScript.Echo("----------------------");
-    WScript.Echo("description = " + e.description);
+    WScript.Echo("description = " + e.message);
     WScript.Echo("stack = " + e.stack);
     for (var p in ex) {
         WScript.Echo(p + " = " + ex[p]);

--- a/test/es6/definegettersetter.js
+++ b/test/es6/definegettersetter.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -85,8 +86,8 @@ var tests = {
             o.__defineGetter__("b", function () { return 4; });
 
             assert.isTrue(o.a === 1, "getter in 'a' should return 1");
-            assert.isTrue((function () { try { o.a = 0; } catch (e) { return e.description; } return null; })() === "2", "setter in 'a' should throw a new Error with number equal to 2");
-            assert.isTrue((function () { try { o.b = 0; } catch (e) { return e.description; } return null; })() === "3", "setter in 'b' should throw a new Error with number equal to 3");
+            assert.isTrue((function () { try { o.a = 0; } catch (e) { return e.message; } return null; })() === "2", "setter in 'a' should throw a new Error with number equal to 2");
+            assert.isTrue((function () { try { o.b = 0; } catch (e) { return e.message; } return null; })() === "3", "setter in 'b' should throw a new Error with number equal to 3");
             assert.isTrue(o.b === 4, "getter in 'b' should return 4");
         }
     },

--- a/test/stackfunc/closure-qmark.js.dbg.baseline
+++ b/test/stackfunc/closure-qmark.js.dbg.baseline
@@ -46,7 +46,6 @@
       "z": "undefined",
       "e": {
         "[prototype]": "undefined",
-        "description": "<large string>",
         "message": "<large string>",
         "number": "-2146823286",
         "stack": "<large string>"
@@ -683,7 +682,6 @@
       "z": "undefined",
       "e": {
         "[prototype]": "undefined",
-        "description": "<large string>",
         "message": "<large string>",
         "number": "-2146823286",
         "stack": "<large string>"

--- a/test/typedarray/dataview.js
+++ b/test/typedarray/dataview.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 var getFuncs = ['getInt8', 'getUint8', 'getInt16', 'getUint16', 'getInt32', 'getUint32', 'getFloat32', 'getFloat64'];
@@ -78,7 +79,7 @@ function testOneOffset(dataView, offSet, value)
                 }
             catch(e)
                 {
-                print("SUCCEEDED: exception " + e.description);
+                print("SUCCEEDED: exception " + e.message);
                 succeeded = true;
                 }
             if (!succeeded)

--- a/test/typedarray/objectproperty.js
+++ b/test/typedarray/objectproperty.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -39,7 +40,7 @@ try {
 }
 catch(e)
 {
-  print("FAILED: get exception " + e.description);
+  print("FAILED: get exception " + e.message);
   hasThrown = true;
 }
 }
@@ -52,7 +53,7 @@ try {
 }
 catch(e)
 {
-  print("SUCCEEDED: get expected exception " + e.description);
+  print("SUCCEEDED: get expected exception " + e.message);
   hasThrown = true;
 }
 if (!hasThrown)
@@ -82,7 +83,7 @@ function verifyOneFunction(func, typedObjectInstances, srcIndex, destIndex, offs
       hasException = true;
       if (!shouldThrow)
       {
-        print("ERROR! throw unexpected exception " + e.description);
+        print("ERROR! throw unexpected exception " + e.message);
       }
     }
     if (!hasException && shouldThrow)
@@ -111,11 +112,11 @@ function verifysubarray(typedObjectInstances, srcIndex, destIndex, offset, shoul
       hasException = true;
       if (!shouldThrow)
       {
-        print("ERROR! throw unexpected exception " + e.description);
+        print("ERROR! throw unexpected exception " + e.message);
       }
       else
       {
-         print("SUCCEEDED in getting exception " + e.description);
+         print("SUCCEEDED in getting exception " + e.message);
       }
     }
     if (!hasException && shouldThrow)
@@ -146,11 +147,11 @@ function verifySet(typedObjectInstances, srcIndex, destIndex, shouldThrow)
       hasException = true;
       if (!shouldThrow)
       {
-        print("ERROR! throw unexpected exception " + e.description);
+        print("ERROR! throw unexpected exception " + e.message);
       }
       else
       {
-         print("SUCCEEDED in getting exception " + e.description);
+         print("SUCCEEDED in getting exception " + e.message);
       }
     }
     if (!hasException && shouldThrow)
@@ -171,7 +172,7 @@ function verifySet(typedObjectInstances, srcIndex, destIndex, shouldThrow)
     }
     catch (e)
     {
-        print("ERROR! throw unexpected exception " + e.description);
+        print("ERROR! throw unexpected exception " + e.message);
     }
 
     print("verify set using "+  typedObjectInstances[destIndex] + " instance " + typedObjectInstances[srcIndex]);
@@ -187,7 +188,7 @@ function verifySet(typedObjectInstances, srcIndex, destIndex, shouldThrow)
     }
     catch (e)
     {
-        print("ERROR! throw unexpected exception " + e.description);
+        print("ERROR! throw unexpected exception " + e.message);
     }
 
     print("verify set to different type");

--- a/test/typedarray/samethread.js
+++ b/test/typedarray/samethread.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -33,7 +34,7 @@ function oneFile(fileName) {
       }
     }
     catch (e) {
-      WScript.Echo("exception is " + e.number + e.description);
+      WScript.Echo("exception is " + e.number + e.message);
     }
   }
 }

--- a/test/typedarray/util.js
+++ b/test/typedarray/util.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -22,7 +23,7 @@ function verifyThrow(func, obj)
     }
     catch(e)
     {
-        print("SUCCEEDED: get expected exception " + e.description);
+        print("SUCCEEDED: get expected exception " + e.message);
         hasThrown = true;
     }
     if (!hasThrown)
@@ -47,7 +48,7 @@ function verifyNoThrow(func, obj)
     }
     catch(e)
     {
-        print("FAILED: get exception " + e.description);
+        print("FAILED: get exception " + e.message);
         hasThrown = true;
     }
     return result;


### PR DESCRIPTION
The Error constructor in ChakraCore had support for an "error number" to do with how it was used in Internet Explorer - this was not compatible with spec.

Additionally there was a `description` property that was sometimes the same as the `message` property but was inconsistent.

Remove all of this.

Fix #5443