### PR TITLE
Fix calling proxy as constructor

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
@@ -2155,7 +2156,7 @@ namespace Js
                 {
                     BEGIN_SAFE_REENTRANT_CALL(scriptContext->GetThreadContext())
                     {
-                        newThisObject = JavascriptOperators::NewScObjectNoCtor(targetObj, scriptContext);
+                        newThisObject = JavascriptOperators::NewScObjectNoCtorCommon(proxy, scriptContext, false);
                     }
                     END_SAFE_REENTRANT_CALL
                     args.Values[0] = newThisObject;

--- a/test/Bugs/bug_OS21193960.js
+++ b/test/Bugs/bug_OS21193960.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -42,7 +43,7 @@ var tests = [
               assert.areEqual(1, ctorCount, "1 === ctorCount");
 
               assert.areEqual(123, newProxy.prop0, "123 === newProxy.prop0");
-              assert.areEqual(0, getCount, "0 === getCount");
+              assert.areEqual(1, getCount, "1 === getCount");
             };
 
             test();
@@ -87,7 +88,7 @@ var tests = [
               assert.areEqual(1, ctorCount, "1 === ctorCount");
 
               assert.areEqual(123, newProxy.prop0, "123 === newProxy.prop0");
-              assert.areEqual(1, getCount, "1 === getCount");
+              assert.areEqual(2, getCount, "2 === getCount");
             };
 
             test();
@@ -146,7 +147,7 @@ var tests = [
               assert.areEqual(1, baseCount, "1 === baseCount");
 
               assert.areEqual(123, newProxy.prop0, "123 === newProxy.prop0");
-              assert.areEqual(1, getCount, "1 === getCount");
+              assert.areEqual(2, getCount, "2 === getCount");
             };
 
             test();

--- a/test/es6/es6HasInstance.js
+++ b/test/es6/es6HasInstance.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -160,7 +161,7 @@ var tests = [
 
             assert.areEqual(false, new ProxyFoo() instanceof ProxyFoo, "new ProxyFoo() instanceof ProxyFoo");
             assert.areEqual(1, checked, "Symbol.hasInstance in a function contructor through proxy - checked==1");
-            assert.areEqual(['Symbol(Symbol.hasInstance)'], checkedString, "checkedString==['Symbol(Symbol.hasInstance)']");
+            assert.areEqual(['prototype', 'Symbol(Symbol.hasInstance)'], checkedString, "checkedString==['Symbol(Symbol.hasInstance)']");
             assert.areEqual(false, new ProxyFoo() instanceof Foo, "new ProxyFoo() instanceof Foo");
             assert.areEqual(2, checked, "Symbol.hasInstance in a function contructor through proxy - checked==2");
         }

--- a/test/es6/proxybugs.js
+++ b/test/es6/proxybugs.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -509,6 +510,17 @@ var tests = [
             Object.defineProperty(desc, "writable", { get: function () { ++counter; return true; }});
             Object.defineProperty(new Proxy({}, handler), "test", desc);
             assert.areEqual(1, counter, "Writable property on descriptor should only be checked once");
+        }
+    },
+    {
+        name : "Proxy without construct trap, should get prototype when constructing",
+        body() {
+            const constructor = function() {}
+            constructor.prototype.a = 5;
+            const p = new Proxy(constructor, {get(a, b, c){ if (b === 'prototype') { return {b : 10} } return Reflect.get(a, b, c);}})
+            const obj = new p();
+            assert.areEqual(obj.b, 10);
+            assert.isUndefined(obj.a);
         }
     }
 ];

--- a/test/es6/proxytest9.baseline
+++ b/test/es6/proxytest9.baseline
@@ -103,8 +103,9 @@ a
 Symbol(b)
 Symbol(c)
 prototype
-1
 prototype
+2
+prototype,prototype
 2
 true
 hasTrap, property : p1


### PR DESCRIPTION
Fix another small spec-deviation/bug

When using `new` on a Proxy if there is no construct trap, the prototype from the target was being used to construct the new object - when it should be getting the prototype from the Proxy (and potentially hitting a `get` trap if there is one).

Fix was just one line - remaining diff is adding a test case + updating tests of incorrect behaviour.

Fix #6597 