### PR TITLE
Load Debugger Baselines on Linux and macOS

### DIFF
--- a/bin/ch/DbgController.js
+++ b/bin/ch/DbgController.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -157,9 +158,10 @@ var controllerObj = (function () {
     function filterFileName(fileName) {
         try {
             var index = fileName.lastIndexOf("\\");
-            if (index >= 0) {
-                return fileName.substring(index + 1);
+            if (index === -1) {
+                index = fileName.lastIndexOf("/");
             }
+            return fileName.substring(index + 1);
         } catch (ex) { }
         return "";
     }

--- a/test/DebuggerCommon/rlexe.xml
+++ b/test/DebuggerCommon/rlexe.xml
@@ -1269,25 +1269,25 @@
   <test>
     <default>
       <files>TypedArray.js</files>
-      <compile-flags>-debuglaunch -dbgbaseline:typedarray.js.dbg.baseline -InspectMaxStringLength:200</compile-flags>
+      <compile-flags>-debuglaunch -dbgbaseline:TypedArray.js.dbg.baseline -InspectMaxStringLength:200</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>ComputedPropertyNames.js</files>
-      <compile-flags>-debuglaunch -dbgbaseline:computedpropertynames.js.dbg.baseline</compile-flags>
+      <compile-flags>-debuglaunch -dbgbaseline:ComputedPropertyNames.js.dbg.baseline</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>parentedDynamicCode2.js</files>
-      <compile-flags>-InspectMaxStringLength:1000 -dbgbaseline:parenteddynamiccode2.js.dbg.baseline</compile-flags>
+      <compile-flags>-InspectMaxStringLength:1000 -dbgbaseline:parentedDynamicCode2.js.dbg.baseline</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>parentedDynamicCode3.js</files>
-      <compile-flags>-InspectMaxStringLength:1000 -dbgbaseline:parenteddynamiccode3.js.dbg.baseline</compile-flags>
+      <compile-flags>-InspectMaxStringLength:1000 -dbgbaseline:parentedDynamicCode3.js.dbg.baseline</compile-flags>
     </default>
   </test>
   <test>
@@ -1301,14 +1301,14 @@
     <default>
       <files>ConsoleScope.js</files>
       <baseline>ConsoleScope.js.baseline</baseline>
-      <compile-flags>-debuglaunch -dbgbaseline:consolescope.js.dbg.baseline</compile-flags>
+      <compile-flags>-debuglaunch -dbgbaseline:ConsoleScope.js.dbg.baseline</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>ConsoleScopePMSpec.js</files>
       <baseline>ConsoleScopePMSpec.js.baseline</baseline>
-      <compile-flags>-debuglaunch -dbgbaseline:consolescopepmspec.js.dbg.baseline</compile-flags>
+      <compile-flags>-debuglaunch -dbgbaseline:ConsoleScopePMSpec.js.dbg.baseline</compile-flags>
     </default>
   </test>
   <test>
@@ -1351,7 +1351,7 @@
   <test>
     <default>
       <files>promiseDisplay.js</files>
-      <compile-flags>-debuglaunch -dbgbaseline:promisedisplay.js.dbg.baseline</compile-flags>
+      <compile-flags>-debuglaunch -dbgbaseline:promiseDisplay.js.dbg.baseline</compile-flags>
     </default>
   </test>
   <test>

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -741,12 +741,8 @@ def main():
             ])
     ] if x.name in args.variants]
 
-    # rm profile.dpl.*
-    for f in glob.glob(test_root + '/*/profile.dpl.*'):
-        os.remove(f)
-
     print('############# ChakraCore Test Suite #############')
-    print('Testing {} build'.format('Test' if flavor is 'Test' else 'Debug'))
+    print('Testing {} build'.format('Test' if flavor == 'Test' else 'Debug'))
     print('Using {} threads'.format(processcount))
     # run each variant
     pool, sequential_pool = Pool(processcount), Pool(1)
@@ -758,6 +754,10 @@ def main():
     failed = any(variant.test_result.fail_count > 0 for variant in variants)
     print('[{} seconds] {}'.format(
         round(elapsed_time.total_seconds(),2), 'Success!' if not failed else 'Failed!'))
+
+    # rm profile.dpl.*
+    for f in glob.glob(test_root + '/*/profile.dpl.*'):
+        os.remove(f)
 
     return 1 if failed else 0
 


### PR DESCRIPTION
Tests of debugger functionality (the ones in the folder test/DebuggerCommon and test/Debugger) use debug baselines in addition to normal baselines. These are loaded in a function within `ch` rather than by the testrunner - this function was windows only hence these test were not running correctly on macOS or Linux.

Fix the function to be xplat so all of these tests will work correctly on Linux and macOS.

Fix: #6619 