### PR TITLE
Fix abort in GetAndClearExceptionWithMetaData when error is on last line of file

### DIFF
--- a/lib/Runtime/Library/JavascriptExceptionMetadata.cpp
+++ b/lib/Runtime/Library/JavascriptExceptionMetadata.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
@@ -105,8 +106,8 @@ namespace Js {
 
         if (nextLine >= cache->GetLineCount())
         {
-            endByteOffset = functionBody->LengthInBytes();
-            endCharOffset = functionBody->LengthInChars();
+            endByteOffset = functionBody->LengthInBytes() + functionBody->StartInDocument();
+            endCharOffset = functionBody->LengthInChars() + functionBody->StartOffset();
         }
         else
         {


### PR DESCRIPTION
There was a bug in getting the source length in GetAndClearExceptionWithMetaData if the error was on the last line of the source file inside a function (not global) Abort would be called.

I introduced this error with an incorrect fix to a previous bug, see: https://github.com/chakra-core/ChakraCore/pull/6412

Prior to my previous fix end of line was being found as:
Length of Function + start of line (too long unless function was all on one line)

I mistakenly changed it to just Length of Function - correct if the function was the global and began at the start of the file, too small if the function began anywhere else.

This fix correctly makes it length of function + start of function.

Fix #6623