### PR TITLE
Throw out-of-bounds error from string SetLength

### DIFF
--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -205,7 +205,7 @@ namespace Js
     {
         if (!IsValidCharCount(newLength))
         {
-            JavascriptExceptionOperators::ThrowOutOfMemory(this->GetScriptContext());
+            JavascriptError::ThrowRangeError(this->GetScriptContext(), JSERR_OutOfBoundString);
         }
         m_charLength = newLength;
     }

--- a/test/Error/outofmem.baseline
+++ b/test/Error/outofmem.baseline
@@ -1,3 +1,3 @@
-Error
-Out of memory
--2146828281
+RangeError
+String length is out of bound
+-2146822618


### PR DESCRIPTION
Use a more appropriate error for out of bounds length in
JavascriptString::SetLength().

Closes #6625
Closes #6632
Closes #6634