### PR TITLE
Fix incorrect abort in EntryIntl_PluralRulesSelect

### DIFF
--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -3128,8 +3128,10 @@ DEFINE_ISXLOCALEAVAILABLE(PR, uloc)
         }, scriptContext->GetRecycler(), &formattedN, &formattedNLength);
 
         double nWithOptions = unum_parseDouble(*nf, reinterpret_cast<UChar *>(formattedN), formattedNLength, nullptr, &status);
-        double roundtripDiff = n - nWithOptions;
-        ICU_ASSERT(status, roundtripDiff <= 1.0 && roundtripDiff >= -1.0);
+
+        ICU_ASSERT(status, (n > 0.0 && nWithOptions <= n && nWithOptions >= 0.0) ||
+            (n < 0.0 && nWithOptions >= n && nWithOptions <= 0) ||
+            (n == 0.0 && nWithOptions == 0));
 
         char16 *selected = nullptr;
         int selectedLength = 0;

--- a/test/Intl/PluralRules.js
+++ b/test/Intl/PluralRules.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -159,6 +160,9 @@ testRunner.runTests([
             test({ maximumSignificantDigits: 1 }, 1.0, "one");
             test({ maximumSignificantDigits: 1 }, 1.1, "one");
             test({ maximumSignificantDigits: 1 }, 1.001, "one");
+            test({ maximumSignificantDigits: 1 }, 110.001, "other");
+            test({ maximumSignificantDigits: 1 }, -110.001, "other");
+            test({ maximumSignificantDigits: 1 }, -1, "one");
 
             // significantDigits should override fractionDigits and integerDigits
             test({ maximumSignificantDigits: 2, maximumFractionDigits: 0 }, 1.1, "other");


### PR DESCRIPTION
When rounding a number to "x significant figures", rounding diff can be arbitrarily large.

There was an ICU_ASSERT (which is actually an abort in release builds) for rounding diffs > 1 which was clearly invalid in many cases.

Assumedly this had been put in because the same code was meant to handle rounding to X decimal places which should always produce a diff < 1; but valid paths must never result in an abort - hence condition relaxed to account for rounding to significant figures.

Fix: #6633
Fix: #6639 
Fix: #6640 
Fix: #6475 