### PR TITLE
Enable Jit for Generators, Asyncs and Async Generators

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "Backend.h"
@@ -149,7 +150,7 @@ Func::Func(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     , m_forInEnumeratorArrayOffset(-1)
     , argInsCount(0)
     , m_globalObjTypeSpecFldInfoArray(nullptr)
-    , m_forInEnumeratorForGeneratorSym(nullptr)
+    , m_generatorFrameSym(nullptr)
 #if LOWER_SPLIT_INT64
     , m_int64SymPairMap(nullptr)
 #endif

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
@@ -1063,21 +1064,21 @@ private:
     StackSym* m_loopParamSym;
     StackSym* m_bailoutReturnValueSym;
     StackSym* m_hasBailedOutSym;
-    StackSym* m_forInEnumeratorForGeneratorSym;
+    StackSym* m_generatorFrameSym;
 
 public:
     StackSym* tempSymDouble;
     StackSym* tempSymBool;
 
-    void SetForInEnumeratorSymForGeneratorSym(StackSym* sym)
+    void SetGeneratorFrameSym(StackSym* sym)
     {
-        Assert(this->m_forInEnumeratorForGeneratorSym == nullptr);
-        this->m_forInEnumeratorForGeneratorSym = sym;
+        Assert(this->m_generatorFrameSym == nullptr);
+        this->m_generatorFrameSym = sym;
     }
 
-    StackSym* GetForInEnumeratorSymForGeneratorSym() const
+    StackSym* GetGeneratorFrameSym() const
     {
-        return this->m_forInEnumeratorForGeneratorSym;
+        return this->m_generatorFrameSym;
     }
 
     // StackSyms' corresponding getters/setters

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -118,6 +118,11 @@ IRBuilder::DoBailOnNoProfile()
         return false;
     }
 
+    if (m_func->GetTopFunc()->GetJITFunctionBody()->IsCoroutine())
+    {
+        return false;
+    }
+
     return true;
 }
 

--- a/lib/Backend/IRBuilder.h
+++ b/lib/Backend/IRBuilder.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
@@ -227,7 +228,7 @@ private:
     IR::RegOpnd *       BuildSrcOpnd(Js::RegSlot srcRegSlot, IRType type = TyVar);
     IR::AddrOpnd *      BuildAuxArrayOpnd(AuxArrayValue auxArrayType, uint32 auxArrayOffset);
     IR::Opnd *          BuildAuxObjectLiteralTypeRefOpnd(int objectId);
-    IR::Opnd *          BuildForInEnumeratorOpnd(uint forInLoopLevel);
+    IR::Opnd *          BuildForInEnumeratorOpnd(uint forInLoopLevel, uint32 offset);
     IR::RegOpnd *       EnsureLoopBodyForInEnumeratorArrayOpnd();
 private:
     uint                AddStatementBoundary(uint statementIndex, uint offset);
@@ -366,29 +367,12 @@ private:
         Func* const m_func;
         IRBuilder* const m_irBuilder;
 
-        // for-in enumerators are allocated on the heap for jit'd loop body
-        // and on the stack for all other cases (the interpreter frame will
-        // reuses them when bailing out). But because we have the concept of
-        // "bailing in" for generator, reusing enumerators allocated on the stack
-        // would not work. So we have to allocate them on the generator's interpreter
-        // frame instead. This operand is loaded as part of the jump table, before we
-        // jump to any of the resume point.
-        IR::RegOpnd* m_forInEnumeratorArrayOpnd = nullptr;
-
         IR::RegOpnd* m_generatorFrameOpnd = nullptr;
-
-        // This label is used to insert any initialization code that might be needed
-        // when bailing in and before jumping to any of the resume points.
-        // As of now, we only need to load the operand for for-in enumerator.
-        IR::LabelInstr* m_initLabel = nullptr;
-
-        IR::RegOpnd* CreateForInEnumeratorArrayOpnd();
 
     public:
         GeneratorJumpTable(Func* func, IRBuilder* irBuilder);
         IR::Instr* BuildJumpTable();
-        IR::LabelInstr* GetInitLabel() const;
-        IR::RegOpnd* EnsureForInEnumeratorArrayOpnd();
+        IR::RegOpnd* BuildForInEnumeratorArrayOpnd(uint32 offset);
     };
 
     GeneratorJumpTable m_generatorJumpTable;

--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -5301,7 +5302,7 @@ bool LinearScan::GeneratorBailIn::NeedsReloadingBackendSymWhenBailingIn(StackSym
 {
     // for-in enumerator in generator is loaded as part of the resume jump table.
     // By the same reasoning as `initializedRegs`'s, we don't have to restore this whether or not it's been spilled.
-    if (this->func->GetForInEnumeratorSymForGeneratorSym() && this->func->GetForInEnumeratorSymForGeneratorSym()->m_id == sym->m_id)
+    if (this->func->GetGeneratorFrameSym() && this->func->GetGeneratorFrameSym()->m_id == sym->m_id)
     {
         return false;
     }

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -673,6 +673,15 @@ PHASE(All)
 #define DEFAULT_CONFIG_ESArrayFindFromLast     (false)
 #define DEFAULT_CONFIG_ESNullishCoalescingOperator (true)
 #define DEFAULT_CONFIG_ESGlobalThis            (true)
+
+// Jitting generators has not been tested on ARM
+// enabled only for x86 and x64 for now
+#ifdef _M_ARM32_OR_ARM64
+    #define DEFAULT_CONFIG_JitES6Generators            (false)
+#else
+    #define DEFAULT_CONFIG_JitES6Generators            (true)
+#endif
+
 #ifdef COMPILE_DISABLE_ES6RegExPrototypeProperties
     // If ES6RegExPrototypeProperties needs to be disabled by compile flag, DEFAULT_CONFIG_ES6RegExPrototypeProperties should be false
     #define DEFAULT_CONFIG_ES6RegExPrototypeProperties (false)
@@ -1206,7 +1215,7 @@ FLAGR(Boolean, ESImportMeta, "Enable import.meta keyword", DEFAULT_CONFIG_ESImpo
 FLAGR(Boolean, ESGlobalThis, "Enable globalThis", DEFAULT_CONFIG_ESGlobalThis)
 
 // This flag to be removed once JITing generator functions is stable
-FLAGNR(Boolean, JitES6Generators        , "Enable JITing of ES6 generators", false)
+FLAGNR(Boolean, JitES6Generators        , "Enable JITing of ES6 generators", DEFAULT_CONFIG_JitES6Generators)
 
 FLAGNR(Boolean, FastLineColumnCalculation, "Enable fast calculation of line/column numbers from the source.", DEFAULT_CONFIG_FastLineColumnCalculation)
 FLAGR (String,  Filename              , "Jscript source file", nullptr)

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeBasePch.h"
@@ -341,13 +342,13 @@ namespace Js
     bool
     FunctionBody::SkipAutoProfileForCoroutine() const
     {
-        return this->IsCoroutine() && CONFIG_ISENABLED(Js::JitES6GeneratorsFlag);
+        return this->IsCoroutine() && CONFIG_FLAG(JitES6Generators);
     }
 
     bool
     FunctionBody::IsGeneratorAndJitIsDisabled() const
     {
-        return this->IsCoroutine() && !(CONFIG_ISENABLED(Js::JitES6GeneratorsFlag) && !this->GetHasTry() && !this->IsInDebugMode() && !this->IsAsync());
+        return this->IsCoroutine() && !(CONFIG_FLAG(JitES6Generators) && !this->GetHasTry() && !this->IsInDebugMode() && !this->IsModule());
     }
 
     ScriptContext* EntryPointInfo::GetScriptContext()
@@ -7151,8 +7152,7 @@ namespace Js
             !GetScriptContext()->IsScriptContextInDebugMode() &&
             DoInterpreterProfile() &&
 #pragma warning(suppress: 6235) // (<non-zero constant> || <expression>) is always a non-zero constant.
-            (!CONFIG_FLAG(NewSimpleJit) || DoInterpreterAutoProfile()) &&
-            !IsCoroutine(); // Generator JIT requires bailout which SimpleJit cannot do since it skips GlobOpt
+            (!CONFIG_FLAG(NewSimpleJit) || DoInterpreterAutoProfile());
     }
 
     bool FunctionBody::DoSimpleJitWithLock() const
@@ -7166,8 +7166,7 @@ namespace Js
             !this->IsInDebugMode() &&
             DoInterpreterProfileWithLock() &&
 #pragma warning(suppress: 6235) // (<non-zero constant> || <expression>) is always a non-zero constant.
-            (!CONFIG_FLAG(NewSimpleJit) || DoInterpreterAutoProfile()) &&
-            !IsCoroutine(); // Generator JIT requires bailout which SimpleJit cannot do since it skips GlobOpt
+            (!CONFIG_FLAG(NewSimpleJit) || DoInterpreterAutoProfile());
     }
 
     bool FunctionBody::DoSimpleJitDynamicProfile() const

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 namespace Js
@@ -42,7 +43,8 @@ namespace Js
             Method                         = 0x400000, // The function is a method
             ComputedName                   = 0x800000,
             ActiveScript                   = 0x1000000,
-            HomeObj                        = 0x2000000
+            HomeObj                        = 0x2000000,
+            GeneratorWithComplexParams     = 0x8000000 // Generator function with non-simple params needs startup yield
         };
         FunctionInfo(JavascriptMethod entryPoint, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = nullptr);
         FunctionInfo(JavascriptMethod entryPoint, _no_write_barrier_tag, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = nullptr);
@@ -136,6 +138,7 @@ namespace Js
         bool GetBaseConstructorKind() const { return (attributes & Attributes::BaseConstructorKind) != 0; }
         bool IsActiveScript() const { return ((this->attributes & Attributes::ActiveScript) != 0); }
         void SetIsActiveScript() { attributes = (Attributes)(attributes | Attributes::ActiveScript); }
+        bool GetGeneratorWithComplexParams() {return (attributes & Attributes::GeneratorWithComplexParams) != 0; }
     protected:
         FieldNoBarrier(JavascriptMethod) originalEntryPoint;
         FieldWithBarrier(FunctionProxy *) functionBodyImpl;     // Implementation of the function- null if the function doesn't have a body

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -9703,9 +9703,11 @@ void EmitGetAsyncIterator(
     // Iterable does not have a Symbol.asyncIterator method: attempt to get a sync
     // iterable and wrap it with an AsyncFromSyncIterator
     writer->MarkLabel(noAsyncIterator);
-    EmitGetIterator(resultReg, iterableReg, byteCodeGenerator, funcInfo);
-    writer->Reg2(Js::OpCode::NewAsyncFromSyncIterator, resultReg, resultReg);
-
+    Js::RegSlot iteratorReg = funcInfo->AcquireTmpRegister();
+    EmitGetIterator(iteratorReg, iterableReg, byteCodeGenerator, funcInfo);
+    writer->Reg2(Js::OpCode::NewAsyncFromSyncIterator, iteratorReg, iteratorReg);
+    writer->Reg2(Js::OpCode::Ld_A_ReuseLoc, resultReg, iteratorReg);    
+    funcInfo->ReleaseTmpRegister(iteratorReg);
     byteCodeGenerator->Writer()->MarkLabel(finished);
 }
 
@@ -10775,9 +10777,18 @@ void EmitYieldStar(
     writer->MarkLabel(noReturnMethod);
 
     if (isAsync)
-        EmitAwait(resumeValueReg, resumeValueReg, byteCodeGenerator, funcInfo);
+    {
+        Js::RegSlot awaitValue = funcInfo->AcquireTmpRegister();
+        writer->Reg2(Js::OpCode::Ld_A, awaitValue, resumeValueReg);
 
-    writer->Reg2(Js::OpCode::Ld_A, yieldStarReg, resumeValueReg);    
+        EmitAwait(awaitValue, awaitValue, byteCodeGenerator, funcInfo);
+        writer->Reg2(Js::OpCode::Ld_A_ReuseLoc, yieldStarReg, awaitValue);
+
+        funcInfo->ReleaseTmpRegister(awaitValue);
+    }
+    else
+        writer->Reg2(Js::OpCode::Ld_A_ReuseLoc, yieldStarReg, resumeValueReg);
+
     writer->Br(finishReturn);
 
     // Throw case: attempt to call throw

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeByteCodePch.h"
@@ -3023,10 +3024,9 @@ void ByteCodeGenerator::EmitOneFunction(ParseNodeFnc *pnodeFnc)
         }
 
         // If the function has non simple parameter list, the params needs to be evaluated when the generator object is created
-        // (that is when the function is called). This yield opcode is to mark the  begining of the function body.
-        // TODO: Inserting a yield should have almost no impact on perf as it is a direct return from the function. But this needs
-        // to be verified. Ideally if the function has simple parameter list then we can avoid inserting the opcode and the additional call.
-        if (pnodeFnc->IsGenerator())
+        // (that is when the function is called). So insert an extra yield we can execute up to, to do this.
+        // In a Module we execute until this yield to hoist functions accross modules.
+        if (pnodeFnc->IsGenerator() && (pnodeFnc->HasNonSimpleParameterList() || pnodeFnc->IsModule()))
         {
             EmitStartupYield(this, funcInfo);
         }

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeByteCodePch.h"
@@ -1240,7 +1241,8 @@ static const Js::FunctionInfo::Attributes StableFunctionInfoAttributesMask = (Js
     Js::FunctionInfo::Attributes::Generator |
     Js::FunctionInfo::Attributes::Module |
     Js::FunctionInfo::Attributes::ComputedName |
-    Js::FunctionInfo::Attributes::HomeObj
+    Js::FunctionInfo::Attributes::HomeObj |
+    Js::FunctionInfo::Attributes::GeneratorWithComplexParams
 );
 
 static Js::FunctionInfo::Attributes GetFunctionInfoAttributes(ParseNodeFnc * pnodeFnc)
@@ -1289,6 +1291,10 @@ static Js::FunctionInfo::Attributes GetFunctionInfoAttributes(ParseNodeFnc * pno
     if (pnodeFnc->IsGenerator())
     {
         attributes = (Js::FunctionInfo::Attributes)(attributes | Js::FunctionInfo::Attributes::Generator);
+        if (pnodeFnc->HasNonSimpleParameterList())
+        {
+            attributes = (Js::FunctionInfo::Attributes)(attributes | Js::FunctionInfo::Attributes::GeneratorWithComplexParams);
+        }
     }
     if (pnodeFnc->IsAccessor())
     {

--- a/lib/Runtime/Debug/TTSnapObjects.cpp
+++ b/lib/Runtime/Debug/TTSnapObjects.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeDebugPch.h"
@@ -2324,9 +2325,9 @@ namespace TTD
                     }
                 }
 
-                generator->SetFrameSlots(generatorInfo->frame_slotCount, frameSlotArray);
                 if (generatorInfo->byteCodeReader_offset > 0)
                 {
+                    generator->SetFrameSlots(generatorInfo->frame_slotCount, frameSlotArray);
                     frame->InitializeClosures();
                     frame->GetReader()->SetCurrentOffset(generatorInfo->byteCodeReader_offset);
                 }

--- a/lib/Runtime/Library/JavascriptAsyncGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptAsyncGeneratorFunction.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
@@ -55,6 +56,7 @@ Var JavascriptAsyncGeneratorFunction::EntryAsyncGeneratorFunctionImplementation(
     auto* generator = library->CreateAsyncGenerator(args, scriptFn, prototype);
 
     // Run the generator to execute until the beginning of the body
+    if (scriptFn->GetFunctionInfo()->GetGeneratorWithComplexParams())
     BEGIN_SAFE_REENTRANT_CALL(scriptContext->GetThreadContext())
     {
         generator->CallGenerator(library->GetUndefined(), ResumeYieldKind::Normal);

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
@@ -120,6 +121,8 @@ using namespace Js;
             prototype);
 
         // Call a next on the generator to execute till the beginning of the body
+        FunctionInfo* funcInfo = generatorFunction->scriptFunction->GetFunctionInfo();
+        if (funcInfo->GetGeneratorWithComplexParams() || funcInfo->IsModule())
         BEGIN_SAFE_REENTRANT_CALL(scriptContext->GetThreadContext())
         {
             generator->CallGenerator(library->GetUndefined(), ResumeYieldKind::Normal);

--- a/test/es6/generator-jit-bugs.js
+++ b/test/es6/generator-jit-bugs.js
@@ -1,20 +1,93 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
+let results = 0;
+let test = 0;
+const verbose = WScript.Arguments[0] != "summary";
+
+function check(actual, expected) {
+    if (actual != expected)
+        throw new Error("Generator produced " + actual + " instead of " + expected);
+    if (verbose)
+        print('Result ' + ++results +  ' Generator correctly produced ' + actual);
+}
+
+function title (name) {
+    if (verbose) {
+        print("Beginning Test " + ++test + ": " + name);
+        results = 0;
+    }
+}
+
+
 // Test 1 - const that is unused/replaced with undefined
-function* foo() {
+title("const that is unused/replaced with undefined");
+function* gf1() {
     const temp2 = null;
     while (true) {
         yield temp2;
     }
 }
 
-const gen = foo();
+const gen = gf1();
 
-gen.next();
-gen.next();
-gen.next();
+check(gen.next().value, null);
+check(gen.next().value, null);
+check(gen.next().value, null);
 
-print("Pass");
+// Test 2 - load for-in enumerator in nested for-in loop
+title("load for-in enumerator in nested for-in loop");
+const arr = [0, 1, 2];
+function* gf2() {
+    for (let a in arr) {
+        for (let b in arr) {
+            yield a + b;
+        }
+    }
+}
+
+const gen2 = gf2();
+
+check(gen2.next().value, "00");
+check(gen2.next().value, "01");
+check(gen2.next().value, "02");
+check(gen2.next().value, "10");
+check(gen2.next().value, "11");
+check(gen2.next().value, "12");
+check(gen2.next().value, "20");
+check(gen2.next().value, "21");
+check(gen2.next().value, "22");
+check(gen2.next().value, undefined);
+
+// Test 3 - Bail on no profile losing loop control variable
+title("Bail on no profile losing loop control variable");
+function* gf3() {
+    for (let i = 0; i < 3; ++i) {
+        yield i;
+    }
+}
+
+const gen3 = gf3();
+
+check(gen3.next().value, 0);
+check(gen3.next().value, 1);
+check(gen3.next().value, 2);
+
+// Test 4 - yield* iterator fails to be restored after Bail on No Profile
+title("Bail on no profile losing yield* iterator")
+function* gf4() {
+    yield 0;
+    yield* [1,2,3];
+}
+
+const gen4 = gf4();
+
+check(gen4.next().value, 0);
+check(gen4.next().value, 1);
+check(gen4.next().value, 2);
+check(gen4.next().value, 3);
+
+print("pass");

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -135,8 +135,22 @@
   <test>
     <default>
       <files>generator-jit-bugs.js</files>
-      <compile-flags>-JitES6Generators</compile-flags>
+      <compile-flags>-JitES6Generators -args summary -endargs</compile-flags>
       <tags>exclude_nonative</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>generator-jit-bugs.js</files>
+      <compile-flags>-JitES6Generators -off:simplejit -args summary -endargs</compile-flags>
+      <tags>exclude_nonative</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>generator-jit-bugs.js</files>
+      <compile-flags>-JitES6Generators -off:fulljit -args summary -endargs</compile-flags>
+      <tags>exclude_nonative, exclude_dynapogo</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
This PR enables the JIT in both FullJit and SimpleJit mode for Generator Functions, Async Functions and Async Generator Functions (Collectively referred to internally as Coroutines)

**Exceptions**
- excludes ARM - I don't have access to an ARM machine to test, and our CI doesn't have ARM so seemed reckless to enable
- excludes functions containing try/catch, may introduce complexities and not yet tested
- disabled when a debugger is attached - may introduce complexities and not yet tested

**Work Done in this PR**
1. Fix register mismatch in Jit
    - This was a bug in `yield*` statements within Async Generators
    - the Lifetime of registers used to store the iterator statement would be incorrect
    - fixed by using additional regs to extend the lifetime

2. Fix handling of For-In
    - For-in loops use an enumerator objector stored in a cache
    - the logic to restore this across `yields` was not working correctly
    - fix by simplifying/removing a couple of steps and moving the load nearer to the point it is used

3. Disable BailOnNoProfile in Coroutines
    - BailOnNoProfile results in code after it being marked as Dead
    - Consider the below example:
    - if a BailOnNoProfile is inserted after the yield the `++i` is marked as dead
    - as `++i` is dead, i is marked as a single definition int - a constant
    - then you get `yield 0` -> BailOnNoProfile -> yield 1 (in the interpreter) -> try jitted code again - Bails out with i = 0 as it is a const -> yield 1 (in the interpreter)
```js
for (let i = 0; i < 3; ++i)
{
  yield i;
} 
```

4. Remove unnecessary startup yield
    - this is a minor optimisation BUT in the context of jitted generators avoids a compulsory extra bailout
    - also makes code much neater

5. Enable
    - change flags so it's all enabled
    - add test cases for key bugs mentioned above


**Future Work**
A. Look at enabling for functions containing try/catch - needs to be explored don't know what issues may arise
B. Create an alternative form of BailOnNoProfile that can be used in Coroutines
C. Look at Jitting loop bodies that don't contain yield - (including loop bodies in Modules)

Fix #5877 