### PR TITLE
NuGet: Remove a redundant code from the source code of packages

### DIFF
--- a/Build/NuGet/Windows.Cpp.All/Items.targets
+++ b/Build/NuGet/Windows.Cpp.All/Items.targets
@@ -11,7 +11,7 @@
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>    
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm\Debug\ChakraCore.dll" />

--- a/Build/NuGet/Windows.Cpp.All/Primary.nuspec
+++ b/Build/NuGet/Windows.Cpp.All/Primary.nuspec
@@ -10,54 +10,54 @@
   </metadata>
   <files>
     <!--Build-->
-    <file src="Items.targets" target="build\native\$id$.targets"/>
+    <file src="Items.targets" target="build\native\$id$.targets" />
 
     <!--Include-->
-    <file src="..\..\..\lib\Jsrt\ChakraCommon.h" target="build\native\include\ChakraCommon.h"/>
-    <file src="..\..\..\lib\Jsrt\ChakraCommonWindows.h" target="build\native\include\ChakraCommonWindows.h"/>
-    <file src="..\..\..\lib\Jsrt\ChakraCore.h" target="build\native\include\ChakraCore.h"/>
-    <file src="..\..\..\lib\Jsrt\ChakraCoreWindows.h" target="build\native\include\ChakraCoreWindows.h"/>
-    <file src="..\..\..\lib\Jsrt\ChakraDebug.h" target="build\native\include\ChakraDebug.h"/>
+    <file src="..\..\..\lib\Jsrt\ChakraCommon.h" target="build\native\include" />
+    <file src="..\..\..\lib\Jsrt\ChakraCommonWindows.h" target="build\native\include" />
+    <file src="..\..\..\lib\Jsrt\ChakraCore.h" target="build\native\include" />
+    <file src="..\..\..\lib\Jsrt\ChakraCoreWindows.h" target="build\native\include" />
+    <file src="..\..\..\lib\Jsrt\ChakraDebug.h" target="build\native\include" />
 
     <!--Lib-->
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.dll" target="lib\native\v140\x86\release\ChakraCore.dll" />
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.lib" target="lib\native\v140\x86\release\ChakraCore.lib" />
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.pdb" target="lib\native\v140\x86\release\ChakraCore.pdb" />
-    <file src="..\..\VcBuild\bin\x86_release\ch.exe" target="lib\native\v140\x86\release\ch.exe" />
-    <file src="..\..\VcBuild\bin\x86_release\ch.pdb" target="lib\native\v140\x86\release\ch.pdb" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.dll" target="lib\native\v140\x86\release" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.lib" target="lib\native\v140\x86\release" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.pdb" target="lib\native\v140\x86\release" />
+    <file src="..\..\VcBuild\bin\x86_release\ch.exe" target="lib\native\v140\x86\release" />
+    <file src="..\..\VcBuild\bin\x86_release\ch.pdb" target="lib\native\v140\x86\release" />
 
     <!--Copying Release to Debug for now to save on build time-->
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.dll" target="lib\native\v140\x86\debug\ChakraCore.dll" />
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.lib" target="lib\native\v140\x86\debug\ChakraCore.lib" />
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.pdb" target="lib\native\v140\x86\debug\ChakraCore.pdb" />
-    <file src="..\..\VcBuild\bin\x86_release\ch.exe" target="lib\native\v140\x86\debug\ch.exe" />
-    <file src="..\..\VcBuild\bin\x86_release\ch.pdb" target="lib\native\v140\x86\debug\ch.pdb" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.dll" target="lib\native\v140\x86\debug" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.lib" target="lib\native\v140\x86\debug" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.pdb" target="lib\native\v140\x86\debug" />
+    <file src="..\..\VcBuild\bin\x86_release\ch.exe" target="lib\native\v140\x86\debug" />
+    <file src="..\..\VcBuild\bin\x86_release\ch.pdb" target="lib\native\v140\x86\debug" />
 
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.dll" target="lib\native\v140\x64\release\ChakraCore.dll" />
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.lib" target="lib\native\v140\x64\release\ChakraCore.lib" />
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.pdb" target="lib\native\v140\x64\release\ChakraCore.pdb" />
-    <file src="..\..\VcBuild\bin\x64_release\ch.exe" target="lib\native\v140\x64\release\ch.exe" />
-    <file src="..\..\VcBuild\bin\x64_release\ch.pdb" target="lib\native\v140\x64\release\ch.pdb" />
-
-    <!--Copying Release to Debug for now to save on build time-->
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.dll" target="lib\native\v140\x64\debug\ChakraCore.dll" />
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.lib" target="lib\native\v140\x64\debug\ChakraCore.lib" />
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.pdb" target="lib\native\v140\x64\debug\ChakraCore.pdb" />
-    <file src="..\..\VcBuild\bin\x64_release\ch.exe" target="lib\native\v140\x64\debug\ch.exe" />
-    <file src="..\..\VcBuild\bin\x64_release\ch.pdb" target="lib\native\v140\x64\debug\ch.pdb" />
-
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.dll" target="lib\native\v140\arm\release\ChakraCore.dll" />
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.lib" target="lib\native\v140\arm\release\ChakraCore.lib" />
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.pdb" target="lib\native\v140\arm\release\ChakraCore.pdb" />
-    <file src="..\..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\release\ch.exe" />
-    <file src="..\..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\release\ch.pdb" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.dll" target="lib\native\v140\x64\release" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.lib" target="lib\native\v140\x64\release" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.pdb" target="lib\native\v140\x64\release" />
+    <file src="..\..\VcBuild\bin\x64_release\ch.exe" target="lib\native\v140\x64\release" />
+    <file src="..\..\VcBuild\bin\x64_release\ch.pdb" target="lib\native\v140\x64\release" />
 
     <!--Copying Release to Debug for now to save on build time-->
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.dll" target="lib\native\v140\arm\debug\ChakraCore.dll" />
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.lib" target="lib\native\v140\arm\debug\ChakraCore.lib" />
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.pdb" target="lib\native\v140\arm\debug\ChakraCore.pdb" />
-    <file src="..\..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\debug\ch.exe" />
-    <file src="..\..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\debug\ch.pdb" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.dll" target="lib\native\v140\x64\debug" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.lib" target="lib\native\v140\x64\debug" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.pdb" target="lib\native\v140\x64\debug" />
+    <file src="..\..\VcBuild\bin\x64_release\ch.exe" target="lib\native\v140\x64\debug" />
+    <file src="..\..\VcBuild\bin\x64_release\ch.pdb" target="lib\native\v140\x64\debug" />
+
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.dll" target="lib\native\v140\arm\release" />
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.lib" target="lib\native\v140\arm\release" />
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.pdb" target="lib\native\v140\arm\release" />
+    <file src="..\..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\release" />
+    <file src="..\..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\release" />
+
+    <!--Copying Release to Debug for now to save on build time-->
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.dll" target="lib\native\v140\arm\debug" />
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.lib" target="lib\native\v140\arm\debug" />
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.pdb" target="lib\native\v140\arm\debug" />
+    <file src="..\..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\debug" />
+    <file src="..\..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\debug" />
 
     $CommonFileElements$
   </files>

--- a/Build/NuGet/Windows.DotNet.All/Items.props
+++ b/Build/NuGet/Windows.DotNet.All/Items.props
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition=" '$(TargetFramework)' == '' Or '$(TargetFramework.TrimEnd(`0123456789`))' == 'net' ">
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*" Condition=" '$(Platform)' == 'AnyCPU' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
       <Link>x86\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*" Condition=" '$(Platform)' == 'AnyCPU' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
       <Link>x64\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*" Condition=" '$(Platform)' == 'AnyCPU' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
       <Link>arm\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
 
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*" Condition=" '$(Platform)' == 'x86' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*.*" Condition=" '$(Platform)' == 'x86' ">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*" Condition=" '$(Platform)' == 'x64' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*.*" Condition=" '$(Platform)' == 'x64' ">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*" Condition=" '$(Platform)' == 'ARM' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*.*" Condition=" '$(Platform)' == 'ARM' ">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/Build/NuGet/Windows.DotNet.All/Primary.nuspec
+++ b/Build/NuGet/Windows.DotNet.All/Primary.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
-  <metadata minClientVersion="3.4">
+  <metadata>
     <id>$id$</id>
     <version>$version$</version>
     <description>$description$</description>
@@ -11,9 +11,9 @@
   <files>
     <file src="Items.props" target="build\$id$.props" />
 
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native\ChakraCore.dll" />
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native\ChakraCore.dll" />
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native\ChakraCore.dll" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native" />
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native" />
 
     $CommonFileElements$
   </files>

--- a/Build/NuGet/Windows.DotNet.All/Symbols.nuspec
+++ b/Build/NuGet/Windows.DotNet.All/Symbols.nuspec
@@ -11,9 +11,9 @@
   <files>
     <file src="Items.props" target="build\$id$.props" />
 
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.pdb" target="runtimes\win7-x86\native\ChakraCore.pdb" />
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.pdb" target="runtimes\win7-x64\native\ChakraCore.pdb" />
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.pdb" target="runtimes\win8-arm\native\ChakraCore.pdb" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.pdb" target="runtimes\win7-x86\native" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.pdb" target="runtimes\win7-x64\native" />
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.pdb" target="runtimes\win8-arm\native" />
 
     $CommonFileElements$
   </files>

--- a/Build/NuGet/Windows.DotNet.Arch/Items.props.mustache
+++ b/Build/NuGet/Windows.DotNet.Arch/Items.props.mustache
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\{{runtimeIdentifier}}\native\*">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\{{runtimeIdentifier}}\native\*.*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/Build/NuGet/Windows.DotNet.Arch/Primary.nuspec
+++ b/Build/NuGet/Windows.DotNet.Arch/Primary.nuspec
@@ -11,7 +11,7 @@
   <files>
     <file src="Items.$platformArchitecture$.props" target="build\$id$.props" />
 
-    <file src="..\..\VcBuild\bin\$platformArchitecture$_release\ChakraCore.dll" target="runtimes\$runtimeIdentifier$\native\ChakraCore.dll" />
+    <file src="..\..\VcBuild\bin\$platformArchitecture$_release\ChakraCore.dll" target="runtimes\$runtimeIdentifier$\native" />
 
     $CommonFileElements$
   </files>


### PR DESCRIPTION
I just removed the redundant code from the packages.

This PR relates to issue #6586.