### PR TITLE
NuGet: Use a more general RID's

### DIFF
--- a/Build/NuGet/Windows.DotNet.All/Items.props
+++ b/Build/NuGet/Windows.DotNet.All/Items.props
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition=" '$(TargetFramework)' == '' Or '$(TargetFramework.TrimEnd(`0123456789`))' == 'net' ">
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
       <Link>x86\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
       <Link>x64\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
       <Link>arm\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
 
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x86\native\*.*" Condition=" '$(Platform)' == 'x86' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\*.*" Condition=" '$(Platform)' == 'x86' ">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win7-x64\native\*.*" Condition=" '$(Platform)' == 'x64' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\*.*" Condition=" '$(Platform)' == 'x64' ">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win8-arm\native\*.*" Condition=" '$(Platform)' == 'ARM' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm\native\*.*" Condition=" '$(Platform)' == 'ARM' ">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/Build/NuGet/Windows.DotNet.All/Primary.nuspec
+++ b/Build/NuGet/Windows.DotNet.All/Primary.nuspec
@@ -11,9 +11,9 @@
   <files>
     <file src="Items.props" target="build\$id$.props" />
 
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win7-x86\native" />
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win7-x64\native" />
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win8-arm\native" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.dll" target="runtimes\win-x86\native" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.dll" target="runtimes\win-x64\native" />
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.dll" target="runtimes\win-arm\native" />
 
     $CommonFileElements$
   </files>

--- a/Build/NuGet/Windows.DotNet.All/Symbols.nuspec
+++ b/Build/NuGet/Windows.DotNet.All/Symbols.nuspec
@@ -11,9 +11,9 @@
   <files>
     <file src="Items.props" target="build\$id$.props" />
 
-    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.pdb" target="runtimes\win7-x86\native" />
-    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.pdb" target="runtimes\win7-x64\native" />
-    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.pdb" target="runtimes\win8-arm\native" />
+    <file src="..\..\VcBuild\bin\x86_release\ChakraCore.pdb" target="runtimes\win-x86\native" />
+    <file src="..\..\VcBuild\bin\x64_release\ChakraCore.pdb" target="runtimes\win-x64\native" />
+    <file src="..\..\VcBuild\bin\arm_release\ChakraCore.pdb" target="runtimes\win-arm\native" />
 
     $CommonFileElements$
   </files>

--- a/Build/NuGet/package-data.xml
+++ b/Build/NuGet/package-data.xml
@@ -29,7 +29,7 @@
     <package id="Microsoft.ChakraCore.X86" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
       <properties>
         <platformArchitecture>x86</platformArchitecture>
-        <runtimeIdentifier>win7-x86</runtimeIdentifier>
+        <runtimeIdentifier>win-x86</runtimeIdentifier>
       </properties>
       <preprocessableFiles>
         <file src="Windows.DotNet.Arch\Items.props.mustache"
@@ -39,7 +39,7 @@
     <package id="Microsoft.ChakraCore.X64" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
       <properties>
         <platformArchitecture>x64</platformArchitecture>
-        <runtimeIdentifier>win7-x64</runtimeIdentifier>
+        <runtimeIdentifier>win-x64</runtimeIdentifier>
       </properties>
       <preprocessableFiles>
         <file src="Windows.DotNet.Arch\Items.props.mustache"
@@ -49,7 +49,7 @@
     <package id="Microsoft.ChakraCore.ARM" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
       <properties>
         <platformArchitecture>arm</platformArchitecture>
-        <runtimeIdentifier>win8-arm</runtimeIdentifier>
+        <runtimeIdentifier>win-arm</runtimeIdentifier>
       </properties>
       <preprocessableFiles>
         <file src="Windows.DotNet.Arch\Items.props.mustache"


### PR DESCRIPTION
In the names of runtime directories are used is quite specific [RID](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog)'s: `win7-x86`, `win7-x64` and `win8-arm`. Usage of such identifiers was justified in early releases of .NET Core 1.0, but for now it's better to switch to using more general identifiers: `win-x86`, `win-x64` and `win-arm`.

This PR relates to issue #6572.