### PR TITLE
NuGet: Use a RID's in package names

### DIFF
--- a/Build/NuGet/package-data.xml
+++ b/Build/NuGet/package-data.xml
@@ -25,8 +25,8 @@
   </commonProperties>
   <packages>
     <package id="Microsoft.ChakraCore" nuspecFile="Windows.DotNet.All\Primary.nuspec" />
-    <package id="Microsoft.ChakraCore.Symbols" nuspecFile="Windows.DotNet.All\Symbols.nuspec" />
-    <package id="Microsoft.ChakraCore.X86" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
+    <package id="Microsoft.ChakraCore.symbols" nuspecFile="Windows.DotNet.All\Symbols.nuspec" />
+    <package id="Microsoft.ChakraCore.win-x86" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
       <properties>
         <platformArchitecture>x86</platformArchitecture>
         <runtimeIdentifier>win-x86</runtimeIdentifier>
@@ -36,7 +36,7 @@
               target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.props" />
       </preprocessableFiles>
     </package>
-    <package id="Microsoft.ChakraCore.X64" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
+    <package id="Microsoft.ChakraCore.win-x64" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
       <properties>
         <platformArchitecture>x64</platformArchitecture>
         <runtimeIdentifier>win-x64</runtimeIdentifier>
@@ -46,7 +46,7 @@
               target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.props" />
       </preprocessableFiles>
     </package>
-    <package id="Microsoft.ChakraCore.ARM" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
+    <package id="Microsoft.ChakraCore.win-arm" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
       <properties>
         <platformArchitecture>arm</platformArchitecture>
         <runtimeIdentifier>win-arm</runtimeIdentifier>


### PR DESCRIPTION
There are already three platform-specific packages, but they just haven't been published. Since we are also planning to create packages for operating systems other than Windows, then we should use a [runtime identifiers](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) in its names. I suggest renaming the platform-specific packages as follows:
   * Microsoft.ChakraCore.X86 -> Microsoft.ChakraCore.win-x86
   * Microsoft.ChakraCore.X64 -> Microsoft.ChakraCore.win-x64
   * Microsoft.ChakraCore.ARM -> Microsoft.ChakraCore.win-arm

This PR relates to issue #6586.