### PR TITLE
NuGet: Implement in MSBuild scripts of platform-specific packages a same deployment mechanism as in the Microsoft.ChakraCore package

### DIFF
--- a/Build/NuGet/Windows.DotNet.Arch/Items.props.mustache
+++ b/Build/NuGet/Windows.DotNet.Arch/Items.props.mustache
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\{{runtimeIdentifier}}\native\*.*">
+  <ItemGroup Condition=" '$(TargetFramework)' == '' Or '$(TargetFramework.TrimEnd(`0123456789`))' == 'net' ">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\{{runtimeIdentifier}}\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
+      <Link>{{platformArchitecture}}\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
+
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\{{runtimeIdentifier}}\native\*.*" Condition=" '$(Platform)' == '{{platformArchitecture}}' ">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>


### PR DESCRIPTION
Currently, platform-specific packages cannot be used together, because their assemblies overwrite each other. To prevent this, in the `.props` files you need to use a code similar to code from the `Microsoft.ChakraCore.props` file.

This PR relates to issue #6586.