### PR TITLE
Check for AsyncGenerator in FillScopeObject

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -7497,8 +7497,8 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
                 DynamicType* newType = nullptr;
                 if (nonSimpleParamList)
                 {
-                    bool skipLetAttrForArguments = ((JavascriptGeneratorFunction::IsBaseGeneratorFunction(funcCallee) || VarIs<JavascriptAsyncFunction>(funcCallee)) ?
-                        VarTo<JavascriptGeneratorFunction>(funcCallee)->GetGeneratorVirtualScriptFunction()->GetFunctionBody()->HasReferenceableBuiltInArguments()
+                    bool skipLetAttrForArguments = ( VarIs<JavascriptGeneratorFunction>(funcCallee) ?
+                        UnsafeVarTo<JavascriptGeneratorFunction>(funcCallee)->GetGeneratorVirtualScriptFunction()->GetFunctionBody()->HasReferenceableBuiltInArguments()
                         : funcCallee->GetFunctionBody()->HasReferenceableBuiltInArguments());
 
                     if (skipLetAttrForArguments)

--- a/test/es7/async-generator-functionality.js
+++ b/test/es7/async-generator-functionality.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -246,6 +247,15 @@ const tests = [
                 ErrorPromise(this.name, ag.throw.call(input), TypeError, `AsyncGenerator.prototype.throw should reject with TypeError when called on ${typeof input} ${input}`);
                 ErrorPromise(this.name, ag.return.call(input), TypeError, `AsyncGenerator.prototype.return should reject with TypeError when called on ${typeof input} ${input}`);
             }
+        }
+    },
+    {
+        name : "AsyncGenerator with complex params containing eval",
+        body() {
+            async function* agf(param = 0) {
+                eval('');
+            }
+            AddPromise(this.name, "Evaluate complex params and perform eval - but nothing to do should close", agf().next(), {done : true});
         }
     }
 ];


### PR DESCRIPTION
Bug introduced by #6456 as that made JavascriptAsyncGeneratoFunction into a sub-class of JavascriptGeneratorFunction.

A check in FillScopeObject was relying on `IsBaseGeneratorFunction` returning true for both JavascriptGeneratorFunction and JavascriptAsyncGeneratorFunction which it was no longer doing.

Instead use `VarIs<JavascriptGeneratorFunction>` which returns true for JavascriptGeneratorFunction, JavascriptAsyncGeneratorFunction and JavascriptAsyncFunction.

Also - minor can use UnsafeVarTo on the line after as the type check has just been done.

Fix: #6682

Thanks for the report @bin2415