### PR TITLE
Disable OpHelperReg optimisation for Coroutines

### DIFF
--- a/lib/Backend/LinearScan.h
+++ b/lib/Backend/LinearScan.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
@@ -296,12 +297,7 @@ private:
         IR::SymOpnd* CreateGeneratorObjectOpnd() const;
 
         // Insert instructions to restore symbols in the `bailInSymbols` list
-        void InsertRestoreSymbols(
-            const BVSparse<JitArenaAllocator>& bytecodeUpwardExposedUses,
-            const BVSparse<JitArenaAllocator>& upwardExposedUses,
-            const CapturedValues& capturedValues,
-            BailInInsertionPoint& insertionPoint
-        );
+        void InsertRestoreSymbols(BailInInsertionPoint& insertionPoint);
 
         // Fill `bailInSymbols` list with all of the symbols that need to be restored
         void BuildBailInSymbolList(

--- a/lib/Backend/SccLiveness.cpp
+++ b/lib/Backend/SccLiveness.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -260,9 +261,19 @@ SCCLiveness::Build()
             {
                 this->EndOpHelper(labelInstr);
             }
-            if (labelInstr->isOpHelper && !PHASE_OFF(Js::OpHelperRegOptPhase, this->func))
+            if (labelInstr->isOpHelper)
             {
-                this->lastOpHelperLabel = labelInstr;
+                if (!PHASE_OFF(Js::OpHelperRegOptPhase, this->func) &&
+                    !this->func->GetTopFunc()->GetJITFunctionBody()->IsCoroutine())
+                {
+                    this->lastOpHelperLabel = labelInstr;
+                }
+#ifdef DBG
+                else
+                {
+                    labelInstr->AsLabelInstr()->m_noHelperAssert = true;
+                }
+#endif
             }
         }
         else if (instr->IsBranchInstr() && !instr->AsBranchInstr()->IsMultiBranch())

--- a/test/es6/generator-jit-bugs.js
+++ b/test/es6/generator-jit-bugs.js
@@ -152,5 +152,21 @@ check(gf8().next().value.v8, 1.1);
 check(gf8().next().value.v8, 1.1);
 check(gf8().next().value.v8, 1.1);
 
+// Test 9 - Invalid OpHelperBlockReg spill
+title("Inner function access after for...in loop containing yield that is not hit")
+{ // Note this bug only occurred when generator was declared inside an outer scope block
+    let i = 0;
+    function* gf9() {
+        function test() {}
+        for (var unused in []) {
+            yield undefined;
+        }
+        if(++i < 4)
+            gf9().next()
+        test + 1;
+    }
+}
+check(gf9().next().done, true);
+
 
 print("pass");


### PR DESCRIPTION
The book keeping for the OpHelperReg optimisation does not always work across yield/await points resulting in potential undefined behaviour.

Disable this optimisation within Coroutines (Generator, Async and AsyncGenerator functions) until/unless a fix can be found.

Additionally the code to spill RAX + RCX/EAX + ECX before GeneratorBailIn was broken - fix it (wrong condition check).

And a little tidy up/removing unused parameters.

Fix: #6704 
Fix: #6691 