### PR TITLE
Fixing a buffer overflow bug in FixedBitVector

### DIFF
--- a/ContributionAgreement.md
+++ b/ContributionAgreement.md
@@ -40,3 +40,4 @@ This agreement has been signed by:
 |Yevhen Lukomskyi|ylukomskyi|
 |Evgeniy Istomin|MadProbe|
 |Wenlu Wang| Kingwl|
+|Kevin Cadieux|kevcadieux|

--- a/lib/Common/DataStructures/FixedBitVector.h
+++ b/lib/Common/DataStructures/FixedBitVector.h
@@ -250,9 +250,10 @@ void BVFixed::SetRange(Container* value, BVIndex start, BVIndex len)
     BVUnit::BVUnitTContainer* bits;
     static_assert(sizeof(Container) == 1 || sizeof(Container) == sizeof(BVUnit::BVUnitTContainer),
         "Container is not suitable to represent the calculated value");
-    if (sizeof(BVUnit::BVUnitTContainer) == 1)
+    if (sizeof(Container) == 1)
     {
-        temp = *((BVUnit::BVUnitTContainer*)value);
+        static_assert(sizeof(byte) == 1, "Size of byte should be 1.");
+        temp = *(byte*)value;
         bits = &temp;
     }
     else

--- a/lib/Common/DataStructures/FixedBitVector.h
+++ b/lib/Common/DataStructures/FixedBitVector.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
-// Copyright (C) Microsoft. All rights reserved.
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once


### PR DESCRIPTION
The `FixedBitVector` implementation contains a buffer overflow bug where a pointer to type of size 1 is reinterpret-casted into a pointer to a bigger type, and then dereferenced. Dereferencing the pointer to type of size bigger than 1 causes more bytes to be read from the buffer than are available. It looks like the code that was meant to ensure the correct pointer type was used was switching on `sizeof(BVUnit::BVUnitTContainer)` instead of `sizeof(Container)`, resulting in using a bigger pointer type when `sizeof(BVUnitTContainer)` is bigger than 1 but `sizeof(Container)` is 1.

This bug was found when building ChakraCore using MSVC with the AddressSanitizer feature turned on. Below is a sample ASan error stack trace:

```
==52436==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x0849c2e0 at pc 0x7b2ab730 bp 0x0849c284 sp 0x0849c278
READ of size 4 at 0x0849c2e0 thread T1
    #0 0x7b2ab72f in BVFixed::SetRange<struct Js::LoopFlags>(struct Js::LoopFlags *,unsigned int,unsigned int) D:\github\ChakraCore\lib\Common\DataStructures\FixedBitVector.h:278
    #1 0x7b2a4399 in Js::DynamicProfileInfo::Initialize(class Js::FunctionBody * const) D:\github\ChakraCore\lib\Runtime\Language\DynamicProfileInfo.cpp:151
    #2 0x7b2a41d2 in Js::DynamicProfileInfo::New(class Memory::Recycler *,class Js::FunctionBody *,bool) D:\github\ChakraCore\lib\Runtime\Language\DynamicProfileInfo.cpp:125
    #3 0x7b040e3e in Js::ScriptContext::AddDynamicProfileInfo<class Memory::WriteBarrierPtr>(class Js::FunctionBody *,class Memory::WriteBarrierPtr<class Js::DynamicProfileInfo> &) D:\github\ChakraCore\lib\Runtime\Base\ScriptContext.cpp:5696
    #4 0x7b00bb15 in Js::FunctionBody::EnsureDynamicProfileInfo(void) D:\github\ChakraCore\lib\Runtime\Base\FunctionBody.cpp:3568
    #5 0x7b00c1c1 in Js::FunctionBody::EnsureDynamicInterpreterThunk(class Js::FunctionEntryPointInfo *) D:\github\ChakraCore\lib\Runtime\Base\FunctionBody.cpp:3870
    #6 0x7b1e5ef2 in Js::InterpreterStackFrame::EnsureDynamicInterpreterThunk(class Js::ScriptFunction *) D:\github\ChakraCore\lib\Runtime\Language\InterpreterStackFrame.cpp:1787
    #7 0x7b1e5e8b in Js::InterpreterStackFrame::DelayDynamicInterpreterThunk(class Js::RecyclableObject *,struct Js::CallInfo,...) D:\github\ChakraCore\lib\Runtime\Language\InterpreterStackFrame.cpp:1757
    #8 0x7b34143d in LocalCallFunction D:\github\ChakraCore\lib\Runtime\Library\JavascriptFunction.cpp:1326
    #9 0x7b346617 in Js::JavascriptFunction::CallFunction<1>(class Js::RecyclableObject *,void * (*)(class Js::RecyclableObject *,struct Js::CallInfo,...),struct Js::Arguments,bool) D:\github\ChakraCore\lib\Runtime\Library\JavascriptFunction.cpp:1345
    #10 0x7b2916e9 in Js::InterpreterStackFrame::OP_CallCommon<struct Js::OpLayoutDynamicProfile<struct Js::OpLayoutT_CallI<struct Js::LayoutSizePolicy<0> > > >(struct Js::OpLayoutDynamicProfile<struct Js::OpLayoutT_CallI<struct Js::LayoutSizePolicy<0> > > const *,class Js::RecyclableObject *,unsigned int,struct Js::AuxArray<unsigned int> const *) D:\github\ChakraCore\lib\Runtime\Language\InterpreterStackFrame.cpp:4000
    #11 0x7b292471 in Js::InterpreterStackFrame::OP_ProfileCallCommon<struct Js::OpLayoutDynamicProfile<struct Js::OpLayoutT_CallI<struct Js::LayoutSizePolicy<0> > > >(struct Js::OpLayoutDynamicProfile<struct Js::OpLayoutT_CallI<struct Js::LayoutSizePolicy<0> > > const *,class Js::RecyclableObject *,unsigned int,unsigned short,unsigned int,struct Js::AuxArray<unsigned int> const *) D:\github\ChakraCore\lib\Runtime\Language\InterpreterStackFrame.cpp:4028
    #12 0x7b271270 in Js::InterpreterStackFrame::OP_ProfiledCallI<struct Js::OpLayoutT_CallI<struct Js::LayoutSizePolicy<0> > >(struct Js::OpLayoutDynamicProfile<struct Js::OpLayoutT_CallI<struct Js::LayoutSizePolicy<0> > > const *) D:\github\ChakraCore\lib\Runtime\Language\InterpreterStackFrame.h:512
    #13 0x7b1f41d9 in Js::InterpreterStackFrame::ProcessProfiled(void) D:\github\ChakraCore\lib\Runtime\Language\InterpreterHandler.inl:85
    #14 0x7b24f64e in Js::InterpreterStackFrame::Process(void) D:\github\ChakraCore\lib\Runtime\Language\InterpreterStackFrame.cpp:3484
    #15 0x7b1e6d77 in Js::InterpreterStackFrame::InterpreterHelper(class Js::ScriptFunction *,struct Js::ArgumentReader,void *,void *,struct Js::InterpreterStackFrame::AsmJsReturnStruct *) D:\github\ChakraCore\lib\Runtime\Language\InterpreterStackFrame.cpp:2165
    #16 0x7b1e5fe0 in Js::InterpreterStackFrame::InterpreterThunk(class Js::JavascriptCallStackLayout *) D:\github\ChakraCore\lib\Runtime\Language\InterpreterStackFrame.cpp:1845
```

