### PR TITLE
Add debug type for Module Namespace

### DIFF
--- a/ContributionAgreement.md
+++ b/ContributionAgreement.md
@@ -40,3 +40,4 @@ This agreement has been signed by:
 |Yevhen Lukomskyi|ylukomskyi|
 |Evgeniy Istomin|MadProbe|
 |Wenlu Wang| Kingwl|
+|Aidan Bickford| BickfordA|

--- a/lib/Jsrt/JsrtDebugUtils.cpp
+++ b/lib/Jsrt/JsrtDebugUtils.cpp
@@ -215,6 +215,11 @@ void JsrtDebugUtils::AddPropertyType(Js::DynamicObject * object, Js::IDiagObject
             addDisplay = true;
             break;
 
+        case Js::TypeIds_ModuleNamespace:
+            JsrtDebugUtils::AddPropertyToObject(object, JsrtDebugPropertyId::type, scriptContext->GetLibrary()->GetModuleTypeDisplayString(), scriptContext);
+            addDisplay = true;
+            break;
+
         case Js::TypeIds_Enumerator:
         case Js::TypeIds_HostDispatch:
         case Js::TypeIds_UnscopablesWrapperObject:

--- a/lib/Jsrt/JsrtDebugUtils.cpp
+++ b/lib/Jsrt/JsrtDebugUtils.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
I have been setting up the debugger from https://github.com/Microsoft/ChakraCore-Debugger and was having trouble debugging modules, as the debugger would crash when reading the type attibute (as it didn't have one).  Seems like that case never got added here. 