### PR TITLE
Fix JsIsCallable

### DIFF
--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "stdafx.h"
@@ -2259,7 +2260,68 @@ namespace JsRTApiTest
     TEST_CASE("ApiTest_ModuleSuccessTest", "[ApiTest]")
     {
         JsRTApiTest::WithSetup(JsRuntimeAttributeEnableExperimentalFeatures, ModuleSuccessTest);
+    }
 
+    void JsIsCallableTest()
+    {
+        JsValueRef callables, callable, index, nonCallables, nonCallable;
+        bool check;
+
+        REQUIRE(JsRunScript(_u("[function(){},function*(){},async function(){},async function*(){},_=>_,async _=>_]"), JS_SOURCE_CONTEXT_NONE, _u(""), &callables) == JsNoError);
+
+        for (int i = 0; i < 6; i++)
+        {
+            REQUIRE(JsIntToNumber(i, &index) == JsNoError);
+            REQUIRE(JsGetIndexedProperty(callables, index, &callable) == JsNoError);
+            REQUIRE(JsIsCallable(callable, &check) == JsNoError);
+            CHECK(check);
+        }
+
+        
+        REQUIRE(JsRunScript(_u("[class{},Math,Reflect,{}]"), JS_SOURCE_CONTEXT_NONE, _u(""), &nonCallables) == JsNoError);
+
+        for (int i = 0; i < 4; i++)
+        {
+            REQUIRE(JsIntToNumber(i, &index) == JsNoError);
+            REQUIRE(JsGetIndexedProperty(nonCallables, index, &nonCallable) == JsNoError);
+            REQUIRE(JsIsCallable(nonCallable, &check) == JsNoError);
+            CHECK(!check);
+        }
+    }
+
+    TEST_CASE("ApiTest_JsIsCallableTest", "[ApiTest]") {
+        JsRTApiTest::RunWithAttributes(JsIsCallableTest);
+    }
+
+    void JsIsConstructorTest()
+    {
+        JsValueRef constructables, constructable, index, nonConstructables, nonConstructable;
+        bool check;
+
+        REQUIRE(JsRunScript(_u("[class{},function(){}]"), JS_SOURCE_CONTEXT_NONE, _u(""), &constructables) == JsNoError);
+
+        for (int i = 0; i < 2; i++)
+        {
+            REQUIRE(JsIntToNumber(i, &index) == JsNoError);
+            REQUIRE(JsGetIndexedProperty(constructables, index, &constructable) == JsNoError);
+            REQUIRE(JsIsConstructor(constructable, &check) == JsNoError);
+            CHECK(check);
+        }
+
+        
+        REQUIRE(JsRunScript(_u("[Math,Reflect,{},function*(){},async function(){},async function*(){},_=>_,async _=>_]"), JS_SOURCE_CONTEXT_NONE, _u(""), &nonConstructables) == JsNoError);
+
+        for (int i = 0; i < 8; i++)
+        {
+            REQUIRE(JsIntToNumber(i, &index) == JsNoError);
+            REQUIRE(JsGetIndexedProperty(nonConstructables, index, &nonConstructable) == JsNoError);
+            REQUIRE(JsIsConstructor(nonConstructable, &check) == JsNoError);
+            CHECK(!check);
+        }
+    }
+
+    TEST_CASE("ApiTest_JsIsConstructorTest", "[ApiTest]") {
+        JsRTApiTest::RunWithAttributes(JsIsConstructorTest);
     }
 
     void SetModuleHostInfoTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)

--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -2262,12 +2262,13 @@ namespace JsRTApiTest
         JsRTApiTest::WithSetup(JsRuntimeAttributeEnableExperimentalFeatures, ModuleSuccessTest);
     }
 
-    void JsIsCallableTest()
+    void JsIsCallableTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
     {
         JsValueRef callables, callable, index, nonCallables, nonCallable;
         bool check;
 
-        REQUIRE(JsRunScript(_u("[function(){},function*(){},async function(){},async function*(){},_=>_,async _=>_]"), JS_SOURCE_CONTEXT_NONE, _u(""), &callables) == JsNoError);
+        REQUIRE(JsRunScript(_u("[function(){},function*(){},async function(){},async function*(){},_=>_,async _=>_]"),
+                            JS_SOURCE_CONTEXT_NONE, _u(""), &callables) == JsNoError);
 
         for (int i = 0; i < 6; i++)
         {
@@ -2293,7 +2294,7 @@ namespace JsRTApiTest
         JsRTApiTest::RunWithAttributes(JsIsCallableTest);
     }
 
-    void JsIsConstructorTest()
+    void JsIsConstructorTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
     {
         JsValueRef constructables, constructable, index, nonConstructables, nonConstructable;
         bool check;
@@ -2309,7 +2310,8 @@ namespace JsRTApiTest
         }
 
         
-        REQUIRE(JsRunScript(_u("[Math,Reflect,{},function*(){},async function(){},async function*(){},_=>_,async _=>_]"), JS_SOURCE_CONTEXT_NONE, _u(""), &nonConstructables) == JsNoError);
+        REQUIRE(JsRunScript(_u("[Math,Reflect,{},function*(){},async function(){},async function*(){},_=>_,async _=>_]"),
+                            JS_SOURCE_CONTEXT_NONE, _u(""), &nonConstructables) == JsNoError);
 
         for (int i = 0; i < 8; i++)
         {

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -1461,7 +1461,8 @@ CHAKRA_API JsIsCallable(_In_ JsValueRef object, _Out_ bool *isCallable)
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
         PARAM_NOT_NULL(isCallable);
 
-        *isCallable = Js::JavascriptConversion::IsCallable(object) && !Js::JavascriptOperators::IsClassConstructor(object) || Js::VarIs<Js::JavascriptGeneratorFunction>(object);
+        *isCallable = (Js::JavascriptConversion::IsCallable(object) && !Js::JavascriptOperators::IsClassConstructor(object)) ||
+                       Js::VarIs<Js::JavascriptGeneratorFunction>(object);
 
         return JsNoError;
     });

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -1461,8 +1461,7 @@ CHAKRA_API JsIsCallable(_In_ JsValueRef object, _Out_ bool *isCallable)
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
         PARAM_NOT_NULL(isCallable);
 
-        *isCallable = (Js::JavascriptConversion::IsCallable(object) && !Js::JavascriptOperators::IsClassConstructor(object)) ||
-                       Js::VarIs<Js::JavascriptGeneratorFunction>(object);
+        *isCallable = Js::JavascriptConversion::IsCallable(object) && !Js::JavascriptOperators::IsClassConstructor(object);
 
         return JsNoError;
     });

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "JsrtPch.h"
@@ -1460,7 +1461,7 @@ CHAKRA_API JsIsCallable(_In_ JsValueRef object, _Out_ bool *isCallable)
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
         PARAM_NOT_NULL(isCallable);
 
-        *isCallable = Js::JavascriptConversion::IsCallable(object);
+        *isCallable = Js::JavascriptConversion::IsCallable(object) && !Js::JavascriptOperators::IsClassConstructor(object) || Js::VarIs<Js::JavascriptGeneratorFunction>(object);
 
         return JsNoError;
     });

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -7290,7 +7290,7 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
     {
         JIT_HELPER_NOT_REENTRANT_NOLOCK_HEADER(Op_IsClassConstructor);
         JavascriptFunction * function = JavascriptOperators::TryFromVar<JavascriptFunction>(instance);
-        return function && (function->GetFunctionInfo()->IsClassConstructor() || (!function->IsScriptFunction() && !function->IsExternalFunction()));
+        return function && function->GetFunctionInfo()->IsClassConstructor();
         JIT_HELPER_END(Op_IsClassConstructor);
     }
 


### PR DESCRIPTION
This PR fixes JsIsCallable JSRT API function which was giving a false-positive when it was called on a class function (e.g. `class _ { }`).
Also this PR adds tests for JsIsCallable and JsIsConstructor, which were missing.

Closes #6720 