### PR TITLE
Make Linux build python version agnostic

### DIFF
--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -1,5 +1,6 @@
+find_package (Python COMPONENTS Interpreter)
 add_custom_target(dbg_controller_h
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/jstoc.py ${CMAKE_CURRENT_SOURCE_DIR}/DbgController.js controllerScript
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/jstoc.py ${CMAKE_CURRENT_SOURCE_DIR}/DbgController.js controllerScript
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/jstoc.py ${CMAKE_CURRENT_SOURCE_DIR}/DbgController.js
   )

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
+# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
@@ -127,7 +128,7 @@ CMAKE_EXPORT_COMPILE_COMMANDS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 LIBS_ONLY_BUILD=
 ALWAYS_YES=
 CCACHE_NAME=
-PYTHON2_BINARY=$(which python2.7 || which python2 || which python 2> /dev/null)
+PYTHON_BINARY=$(which python3 || which python || which python2.7 || which python2 || which python 2> /dev/null)
 
 UNAME_S=`uname -s`
 if [[ $UNAME_S =~ 'Linux' ]]; then
@@ -538,7 +539,7 @@ export TARGET_PATH
 
 if [[ $HAS_LTTNG == 1 ]]; then
     CHAKRACORE_ROOT=`dirname $0`
-    "$PYTHON2_BINARY" $CHAKRACORE_ROOT/tools/lttng.py --man $CHAKRACORE_ROOT/manifests/Microsoft-Scripting-Chakra-Instrumentation.man --intermediate $TARGET_PATH/intermediate
+    "$PYTHON_BINARY" $CHAKRACORE_ROOT/tools/lttng.py --man $CHAKRACORE_ROOT/manifests/Microsoft-Scripting-Chakra-Instrumentation.man --intermediate $TARGET_PATH/intermediate
     mkdir -p $TARGET_PATH/lttng
     (diff -q $TARGET_PATH/intermediate/lttng/jscriptEtw.h $TARGET_PATH/lttng/jscriptEtw.h && echo "jscriptEtw.h up to date; skipping") || cp $TARGET_PATH/intermediate/lttng/* $TARGET_PATH/lttng/
 fi
@@ -553,8 +554,8 @@ fi
 BUILD_DIRECTORY="${TARGET_PATH}/${BUILD_TYPE_DIR:0}"
 echo "Build path: ${BUILD_DIRECTORY}"
 
-BUILD_RELATIVE_DIRECTORY=$("$PYTHON2_BINARY" -c "import os.path;print \
-    os.path.relpath('${CHAKRACORE_DIR}', '$BUILD_DIRECTORY')")
+BUILD_RELATIVE_DIRECTORY=$("$PYTHON_BINARY" -c "from __future__ import print_function; import os.path;\
+    print(os.path.relpath('${CHAKRACORE_DIR}', '$BUILD_DIRECTORY'))")
 
 ################# Write-barrier check/analyze run #################
 WB_FLAG=


### PR DESCRIPTION
Ubuntu 20.04 comes with python3 only AND its shell python command is `python3` not `python`.

Older linux distros come with python 2 only.

**Two changes to handle this**
1. Our `build.sh` script was dependent on finding python2, this change should cause it to function with python3 or python2
2. the `jstoc.py` script run as part of building `ch` required a command line `python` command, this change asks CMake to locate a python executable and use it rather than relying on the existence of a command line `python` command

**Note this was not an issue in CI because:**
a) we don't use `build.sh` in the CI AND
b) the CI machines have a symlink between `python` and `python3` - but this is something in azure CI, it's not default on a blank Ubuntu 20.04 distro

**CC** @fatcerberus 

Fix #6731