### PR TITLE
Replace expired discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ChakraCore
 
-[![Discord Chat](https://img.shields.io/discord/695166668967510077?label=Discord&logo=Discord)](https://discord.gg/vT5J7adt)
+[![Discord Chat](https://img.shields.io/discord/695166668967510077?label=Discord&logo=Discord)](https://discord.gg/dgRawPdNuC)
 [![Licensed under the MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt)
 [![PR's Welcome](https://img.shields.io/badge/PRs%20-welcome-brightgreen.svg)](#contribute)
 


### PR DESCRIPTION
The discord link in the readme had expired this PR replaces it with a new, functioning one.

Fix #6734 