### PR TITLE
Fix for JsPointerToString and JsCreateString #6669

### DIFF
--- a/ContributionAgreement.md
+++ b/ContributionAgreement.md
@@ -43,3 +43,4 @@ This agreement has been signed by:
 |Kevin Cadieux|kevcadieux|
 |Aidan Bickford| BickfordA|
 |Ryoichi Kaida| camcam-lemon|
+|Christopher Raney| dagarxji|

--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -165,12 +165,12 @@ namespace JsRTApiTest
         JsValueRef value2 = JS_INVALID_REFERENCE;
         REQUIRE(JsPointerToString(_u("value1"), wcslen(_u("value1")), &value2) == JsNoError);
 
-		// Test JsPointerToString and JsCreateString on NULL inputs
-		JsValueRef nullStr;
-		REQUIRE(JsPointerToString(NULL, 0, &nullStr) == JsNoError);
+        // Test JsPointerToString and JsCreateString on NULL inputs
+        JsValueRef nullStr;
+        REQUIRE(JsPointerToString(NULL, 0, &nullStr) == JsNoError);
 
-		JsValueRef nullFname;
-		REQUIRE(JsCreateString(NULL, 0, &nullFname) == JsNoError);
+        JsValueRef nullFname;
+        REQUIRE(JsCreateString(NULL, 0, &nullFname) == JsNoError);
 
         REQUIRE(JsSetProperty(object, name1, value1, true) == JsNoError);
         REQUIRE(JsSetProperty(object, name2, value2, true) == JsNoError);

--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -165,6 +165,13 @@ namespace JsRTApiTest
         JsValueRef value2 = JS_INVALID_REFERENCE;
         REQUIRE(JsPointerToString(_u("value1"), wcslen(_u("value1")), &value2) == JsNoError);
 
+		// Test JsPointerToString and JsCreateString on NULL inputs
+		JsValueRef nullStr;
+		REQUIRE(JsPointerToString(NULL, 0, &nullStr) == JsNoError);
+
+		JsValueRef nullFname;
+		REQUIRE(JsCreateString(NULL, 0, &nullFname) == JsNoError);
+
         REQUIRE(JsSetProperty(object, name1, value1, true) == JsNoError);
         REQUIRE(JsSetProperty(object, name2, value2, true) == JsNoError);
 

--- a/lib/Jsrt/ChakraCommonWindows.h
+++ b/lib/Jsrt/ChakraCommonWindows.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -323,12 +324,12 @@
     ///     Creates a string value from a string pointer.
     /// </summary>
     /// <remarks>
-	///		<para>
-	///         Requires an active script context.
-	///     </para>
-	///     <para>
-	///         Providing length of 0 will ignore input string pointer and return a Js empty string.
-	///     </para>
+    ///     <para>
+    ///         Requires an active script context.
+    ///     </para>
+    ///     <para>
+    ///         Providing length of 0 will ignore input string pointer and return a Js empty string.
+    ///     </para>
     /// </remarks>
     /// <param name="stringValue">The string pointer to convert to a string value.</param>
     /// <param name="stringLength">The length of the string to convert.</param>

--- a/lib/Jsrt/ChakraCommonWindows.h
+++ b/lib/Jsrt/ChakraCommonWindows.h
@@ -323,7 +323,12 @@
     ///     Creates a string value from a string pointer.
     /// </summary>
     /// <remarks>
-    ///     Requires an active script context.
+	///		<para>
+	///         Requires an active script context.
+	///     </para>
+	///     <para>
+	///         Providing length of 0 will ignore input string pointer and return a Js empty string.
+	///     </para>
     /// </remarks>
     /// <param name="stringValue">The string pointer to convert to a string value.</param>
     /// <param name="stringLength">The length of the string to convert.</param>
@@ -333,7 +338,7 @@
     /// </returns>
     CHAKRA_API
         JsPointerToString(
-            _In_reads_(stringLength) const wchar_t *stringValue,
+            _In_reads_opt_(stringLength) const wchar_t *stringValue,
             _In_ size_t stringLength,
             _Out_ JsValueRef *value);
 

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -505,6 +505,9 @@ typedef bool (CHAKRA_CALLBACK * JsSerializedLoadScriptCallback)
 ///     <para>
 ///         Input string can be either ASCII or Utf8
 ///     </para>
+///     <para>
+///         Providing length of 0 will ignore input string pointer and return a Js empty string.
+///     </para>
 /// </remarks>
 /// <param name="content">Pointer to string memory.</param>
 /// <param name="length">Number of bytes within the string</param>
@@ -514,7 +517,7 @@ typedef bool (CHAKRA_CALLBACK * JsSerializedLoadScriptCallback)
 /// </returns>
 CHAKRA_API
     JsCreateString(
-        _In_ const char *content,
+        _In_opt_ const char *content,
         _In_ size_t length,
         _Out_ JsValueRef *value);
 

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 /// \mainpage Chakra Hosting API Reference

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -868,10 +868,15 @@ static void CastCopy(const SrcChar* src, DstChar* dst, size_t count)
 }
 
 CHAKRA_API JsCreateString(
-    _In_ const char *content,
+    _In_opt_ const char *content,
     _In_ size_t length,
     _Out_ JsValueRef *value)
 {
+	if (length == 0)
+	{
+		content = "";
+	}
+
     PARAM_NOT_NULL(content);
     PARAM_NOT_NULL(value);
     *value = JS_INVALID_REFERENCE;

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -872,12 +872,11 @@ CHAKRA_API JsCreateString(
     _In_ size_t length,
     _Out_ JsValueRef *value)
 {
-	if (length == 0)
-	{
-		content = "";
-	}
+    if (length != 0)
+    {
+        PARAM_NOT_NULL(content);
+    }
 
-    PARAM_NOT_NULL(content);
     PARAM_NOT_NULL(value);
     *value = JS_INVALID_REFERENCE;
 
@@ -893,12 +892,19 @@ CHAKRA_API JsCreateString(
 
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
 
-        Js::JavascriptString *stringValue = Js::LiteralStringWithPropertyStringPtr::
-            NewFromCString(content, (CharCount)length, scriptContext->GetLibrary());
+        if (length != 0)
+        {
+            Js::JavascriptString *stringValue = Js::LiteralStringWithPropertyStringPtr::
+                NewFromCString(content, (CharCount)length, scriptContext->GetLibrary());
 
-        PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTCreateString, stringValue->GetSz(), stringValue->GetLength());
+            PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTCreateString, stringValue->GetSz(), stringValue->GetLength());
 
-        *value = stringValue;
+            *value = stringValue;
+        }
+        else
+        {
+            *value = scriptContext->GetLibrary()->GetEmptyString();
+        }
 
         PERFORM_JSRT_TTD_RECORD_ACTION_RESULT(scriptContext, value);
 

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -891,14 +891,11 @@ CHAKRA_API JsCreateString(
     }
 
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
-
+        Js::JavascriptString *stringValue = Js::LiteralStringWithPropertyStringPtr::
+        NewFromCString(content, (CharCount)length, scriptContext->GetLibrary());
+        PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTCreateString, stringValue->GetSz(), stringValue->GetLength());
         if (length != 0)
         {
-            Js::JavascriptString *stringValue = Js::LiteralStringWithPropertyStringPtr::
-                NewFromCString(content, (CharCount)length, scriptContext->GetLibrary());
-
-            PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTCreateString, stringValue->GetSz(), stringValue->GetLength());
-
             *value = stringValue;
         }
         else

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "JsrtPch.h"
@@ -1233,24 +1234,23 @@ CHAKRA_API JsPointerToString(_In_reads_opt_(stringLength) const WCHAR *stringVal
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
         PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTCreateString, stringValue, stringLength);
-		
-		PARAM_NOT_NULL(string);
+        
+        PARAM_NOT_NULL(string);
 
-		if (stringLength == 0)
-		{
-			*string = scriptContext->GetLibrary()->GetEmptyString();
-		}
-		else
-		{
-			PARAM_NOT_NULL(stringValue);
-			
-
-			if (!Js::IsValidCharCount(stringLength))
-			{
-				Js::JavascriptError::ThrowOutOfMemoryError(scriptContext);
-			}
-			*string = Js::JavascriptString::NewCopyBuffer(stringValue, static_cast<charcount_t>(stringLength), scriptContext);
-		}
+        if (stringLength == 0)
+        {
+            *string = scriptContext->GetLibrary()->GetEmptyString();
+        }
+        else
+        {
+            PARAM_NOT_NULL(stringValue);
+            
+            if (!Js::IsValidCharCount(stringLength))
+            {
+                Js::JavascriptError::ThrowOutOfMemoryError(scriptContext);
+            }
+            *string = Js::JavascriptString::NewCopyBuffer(stringValue, static_cast<charcount_t>(stringLength), scriptContext);
+        }
 
         PERFORM_JSRT_TTD_RECORD_ACTION_RESULT(scriptContext, string);
 

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -1229,20 +1229,28 @@ CHAKRA_API JsGetStringLength(_In_ JsValueRef value, _Out_ int *length)
     END_JSRT_NO_EXCEPTION
 }
 
-CHAKRA_API JsPointerToString(_In_reads_(stringLength) const WCHAR *stringValue, _In_ size_t stringLength, _Out_ JsValueRef *string)
+CHAKRA_API JsPointerToString(_In_reads_opt_(stringLength) const WCHAR *stringValue, _In_ size_t stringLength, _Out_ JsValueRef *string)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
         PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTCreateString, stringValue, stringLength);
+		
+		PARAM_NOT_NULL(string);
 
-        PARAM_NOT_NULL(stringValue);
-        PARAM_NOT_NULL(string);
+		if (stringLength == 0)
+		{
+			*string = scriptContext->GetLibrary()->GetEmptyString();
+		}
+		else
+		{
+			PARAM_NOT_NULL(stringValue);
+			
 
-        if (!Js::IsValidCharCount(stringLength))
-        {
-            Js::JavascriptError::ThrowOutOfMemoryError(scriptContext);
-        }
-
-        *string = Js::JavascriptString::NewCopyBuffer(stringValue, static_cast<charcount_t>(stringLength), scriptContext);
+			if (!Js::IsValidCharCount(stringLength))
+			{
+				Js::JavascriptError::ThrowOutOfMemoryError(scriptContext);
+			}
+			*string = Js::JavascriptString::NewCopyBuffer(stringValue, static_cast<charcount_t>(stringLength), scriptContext);
+		}
 
         PERFORM_JSRT_TTD_RECORD_ACTION_RESULT(scriptContext, string);
 


### PR DESCRIPTION
#6669
- Update for JsPointerToString and JsCreateString to ignore input string if length is 0. The function will return an empty string instead of JsErrorNullArgument.
- This passed all unit tests.
- The test included in the JsRTApiTest will fail without these changes.

Tagged as per issue request:
@rhuanjl 