### PR TITLE
Resolved JsCreateString & JsPointerToString #6669

### DIFF
--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -164,6 +164,12 @@ namespace JsRTApiTest
 
         JsValueRef value2 = JS_INVALID_REFERENCE;
         REQUIRE(JsPointerToString(_u("value1"), wcslen(_u("value1")), &value2) == JsNoError);
+        //Testing JsPointerToString and JsCreateString on NULL inputs 
+        JsValueRef nullStr;
+        REQUIRE(JsPointerToString(NULL, 0, &nullStr) == JsNoError);
+
+		JsValueRef nullFname;
+		REQUIRE(JsCreateString(NULL, 0, &nullFname) == JsNoError);
 
         REQUIRE(JsSetProperty(object, name1, value1, true) == JsNoError);
         REQUIRE(JsSetProperty(object, name2, value2, true) == JsNoError);

--- a/lib/Jsrt/ChakraCommonWindows.h
+++ b/lib/Jsrt/ChakraCommonWindows.h
@@ -328,12 +328,13 @@
     /// <param name="stringValue">The string pointer to convert to a string value.</param>
     /// <param name="stringLength">The length of the string to convert.</param>
     /// <param name="value">The new string value.</param>
+    //<para> if stringlength = 0, a JS Empty string will be returned
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
     CHAKRA_API
         JsPointerToString(
-            _In_reads_(stringLength) const wchar_t *stringValue,
+            _In_reads_opt_(stringLength) const wchar_t *stringValue,
             _In_ size_t stringLength,
             _Out_ JsValueRef *value);
 

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -511,10 +511,12 @@ typedef bool (CHAKRA_CALLBACK * JsSerializedLoadScriptCallback)
 /// <param name="value">JsValueRef representing the JavascriptString</param>
 /// <returns>
 ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+//<para> Have handled NULL Values by changing _In_ to _In_opt_ </para>
 /// </returns>
 CHAKRA_API
     JsCreateString(
-        _In_ const char *content,
+        
+        _In_opt_ const char *content,
         _In_ size_t length,
         _Out_ JsValueRef *value);
 

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -868,7 +868,7 @@ static void CastCopy(const SrcChar* src, DstChar* dst, size_t count)
 }
 
 CHAKRA_API JsCreateString(
-    _In_ const char *content,
+    _In_opt_ const char *content,
     _In_ size_t length,
     _Out_ JsValueRef *value)
 {
@@ -902,7 +902,7 @@ CHAKRA_API JsCreateString(
 }
 
 CHAKRA_API JsCreateStringUtf16(
-    _In_ const uint16_t *content,
+    _In_opt_ const uint16_t *content,
     _In_ size_t length,
     _Out_ JsValueRef *value)
 {

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -1229,21 +1229,26 @@ CHAKRA_API JsGetStringLength(_In_ JsValueRef value, _Out_ int *length)
     END_JSRT_NO_EXCEPTION
 }
 
-CHAKRA_API JsPointerToString(_In_reads_(stringLength) const WCHAR *stringValue, _In_ size_t stringLength, _Out_ JsValueRef *string)
+CHAKRA_API JsPointerToString(_In_reads_opt_ (stringLength) const WCHAR *stringValue, _In_ size_t stringLength, _Out_ JsValueRef *string)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
         PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTCreateString, stringValue, stringLength);
 
-        PARAM_NOT_NULL(stringValue);
         PARAM_NOT_NULL(string);
 
-        if (!Js::IsValidCharCount(stringLength))
-        {
-            Js::JavascriptError::ThrowOutOfMemoryError(scriptContext);
-        }
-
-        *string = Js::JavascriptString::NewCopyBuffer(stringValue, static_cast<charcount_t>(stringLength), scriptContext);
-
+        if (stringLength == 0)
+		{
+			*string = scriptContext->GetLibrary()->GetEmptyString();
+		}
+		else{
+			PARAM_NOT_NULL(stringValue);
+			if (!Js::IsValidCharCount(stringLength))
+			{
+				Js::JavascriptError::ThrowOutOfMemoryError(scriptContext);
+			}
+			*string = Js::JavascriptString::NewCopyBuffer(stringValue, static_cast<charcount_t>(stringLength), scriptContext);
+		}
+        
         PERFORM_JSRT_TTD_RECORD_ACTION_RESULT(scriptContext, string);
 
         return JsNoError;


### PR DESCRIPTION
Since I am new to Open-Source, I picked this issue. Following the instructions, I have:

1. Changed the SAL annotation for the string input parameter from _In_ to _In_opt_, I also read up [relevant documentation](https://docs.microsoft.com/en-us/cpp/code-quality/understanding-sal?view=msvc-160) for the same which helped in understanding NULL Value handling.

2. I have also changed the implementation, added the test cases & updated the comments in the headers which mention that 0 lengths will ignore the input string pointer and return a Js empty string.

3. The Added test cases that were previously not working are working now. 

4. I also glanced through the active contributions for the same issue by @dagarxji, and tried to solve the last issue raised by @rhuanjl regarding the PERFORM_JSRT_TTD_RECORD_ACTION macro & checked in case it is inside an if-conditional. 

5. I spent a majority of my time [understanding Chakra](https://blogs.windows.com/msedgedev/2015/12/05/open-source-chakra-core/) & the code-flow, the thought behind has been really instructional. Already loving the inclusivity of the community. 