### PR TITLE
NuGet: Add to platform-specific packages a PowerShell scripts that are responsible for deploying assemblies on ASP.NET 4.X websites

### DIFF
--- a/Build/NuGet/Windows.DotNet.Arch/Install.ps1.mustache
+++ b/Build/NuGet/Windows.DotNet.Arch/Install.ps1.mustache
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------------------------------------------
+# Copyright (C) Microsoft. All rights reserved.
+# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+#-------------------------------------------------------------------------------------------------------
+
+param($installPath, $toolsPath, $package, $project)
+
+if ($project.Type -eq 'Web Site') {
+    $projectDir = $project.Properties.Item('FullPath').Value
+
+    $assemblyDestDir = Join-Path $projectDir 'bin/{{{platformArchitecture}}}'
+    if (!(Test-Path $assemblyDestDir)) {
+        New-Item -ItemType Directory -Force -Path $assemblyDestDir
+    }
+
+    $assemblySourceFiles = Join-Path $installPath 'runtimes/{{{runtimeIdentifier}}}/native/*.*'
+    Copy-Item $assemblySourceFiles $assemblyDestDir -Force
+}

--- a/Build/NuGet/Windows.DotNet.Arch/Primary.nuspec
+++ b/Build/NuGet/Windows.DotNet.Arch/Primary.nuspec
@@ -10,6 +10,8 @@
   </metadata>
   <files>
     <file src="Items.$platformArchitecture$.props" target="build\$id$.props" />
+    <file src="Install.$platformArchitecture$.ps1" target="tools\Install.ps1" />
+    <file src="Uninstall.$platformArchitecture$.ps1" target="tools\Uninstall.ps1" />
 
     <file src="..\..\VcBuild\bin\$platformArchitecture$_release\ChakraCore.dll" target="runtimes\$runtimeIdentifier$\native" />
 

--- a/Build/NuGet/Windows.DotNet.Arch/Uninstall.ps1.mustache
+++ b/Build/NuGet/Windows.DotNet.Arch/Uninstall.ps1.mustache
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------------------------------------------
+# Copyright (C) Microsoft. All rights reserved.
+# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+#-------------------------------------------------------------------------------------------------------
+
+param($installPath, $toolsPath, $package, $project)
+
+if ($project.Type -eq 'Web Site') {
+    $projectDir = $project.Properties.Item('FullPath').Value
+    $assemblySourceFiles = Join-Path $installPath 'runtimes/{{{runtimeIdentifier}}}/native/*.*'
+
+    foreach ($assemblySourceFileInfo in Get-Item($assemblySourceFiles)) {
+        $assemblyFile = Join-Path $projectDir "bin/{{{platformArchitecture}}}/$($assemblySourceFileInfo.Name)"
+        if (Test-Path $assemblyFile) {
+            Remove-Item $assemblyFile -Force
+        }
+    }
+}

--- a/Build/NuGet/package-data.xml
+++ b/Build/NuGet/package-data.xml
@@ -34,6 +34,10 @@
       <preprocessableFiles>
         <file src="Windows.DotNet.Arch\Items.props.mustache"
               target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.props" />
+        <file src="Windows.DotNet.Arch\Install.ps1.mustache"
+              target="Windows.DotNet.Arch\Install.{{{platformArchitecture}}}.ps1" />
+        <file src="Windows.DotNet.Arch\Uninstall.ps1.mustache"
+              target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.ps1" />
       </preprocessableFiles>
     </package>
     <package id="Microsoft.ChakraCore.win-x64" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
@@ -44,6 +48,10 @@
       <preprocessableFiles>
         <file src="Windows.DotNet.Arch\Items.props.mustache"
               target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.props" />
+        <file src="Windows.DotNet.Arch\Install.ps1.mustache"
+              target="Windows.DotNet.Arch\Install.{{{platformArchitecture}}}.ps1" />
+        <file src="Windows.DotNet.Arch\Uninstall.ps1.mustache"
+              target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.ps1" />
       </preprocessableFiles>
     </package>
     <package id="Microsoft.ChakraCore.win-arm" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
@@ -54,6 +62,10 @@
       <preprocessableFiles>
         <file src="Windows.DotNet.Arch\Items.props.mustache"
               target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.props" />
+        <file src="Windows.DotNet.Arch\Install.ps1.mustache"
+              target="Windows.DotNet.Arch\Install.{{{platformArchitecture}}}.ps1" />
+        <file src="Windows.DotNet.Arch\Uninstall.ps1.mustache"
+              target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.ps1" />
       </preprocessableFiles>
     </package>
     <package id="Microsoft.ChakraCore.vc140" nuspecFile="Windows.Cpp.All\Primary.nuspec">


### PR DESCRIPTION
Unfortunately, MSBuild scripts are not suitable for all use cases of .NET Framework. For example, ASP.NET 4.X web sites don't have project files and need to use a PowerShell scripts to deploy the native assemblies in the `bin` directory. To make it possible to use packages on ASP.NET 4.X web sites, we will add the `Install.ps1` and `Uninstall.ps1` scripts to platform-specific packages.

This PR relates to issue #6586.