### PR TITLE
NuGet: Add a platform-specific “symbol” packages

### DIFF
--- a/Build/NuGet/Windows.DotNet.Arch/Symbols.nuspec
+++ b/Build/NuGet/Windows.DotNet.Arch/Symbols.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <description>$description$</description>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$</tags>
+    $CommonMetadataElements$
+  </metadata>
+  <files>
+    <file src="Items.$platformArchitecture$.symbols.props" target="build\$id$.props" />
+    <file src="Install.$platformArchitecture$.symbols.ps1" target="tools\Install.ps1" />
+    <file src="Uninstall.$platformArchitecture$.symbols.ps1" target="tools\Uninstall.ps1" />
+
+    <file src="..\..\VcBuild\bin\$platformArchitecture$_release\ChakraCore.pdb" target="runtimes\$runtimeIdentifier$\native" />
+
+    $CommonFileElements$
+  </files>
+</package>

--- a/Build/NuGet/package-data.xml
+++ b/Build/NuGet/package-data.xml
@@ -40,6 +40,20 @@
               target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.ps1" />
       </preprocessableFiles>
     </package>
+    <package id="Microsoft.ChakraCore.win-x86.symbols" nuspecFile="Windows.DotNet.Arch\Symbols.nuspec">
+      <properties>
+        <platformArchitecture>x86</platformArchitecture>
+        <runtimeIdentifier>win-x86</runtimeIdentifier>
+      </properties>
+      <preprocessableFiles>
+        <file src="Windows.DotNet.Arch\Items.props.mustache"
+              target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.symbols.props" />
+        <file src="Windows.DotNet.Arch\Install.ps1.mustache"
+              target="Windows.DotNet.Arch\Install.{{{platformArchitecture}}}.symbols.ps1" />
+        <file src="Windows.DotNet.Arch\Uninstall.ps1.mustache"
+              target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.symbols.ps1" />
+      </preprocessableFiles>
+    </package>
     <package id="Microsoft.ChakraCore.win-x64" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
       <properties>
         <platformArchitecture>x64</platformArchitecture>
@@ -54,6 +68,20 @@
               target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.ps1" />
       </preprocessableFiles>
     </package>
+    <package id="Microsoft.ChakraCore.win-x64.symbols" nuspecFile="Windows.DotNet.Arch\Symbols.nuspec">
+      <properties>
+        <platformArchitecture>x64</platformArchitecture>
+        <runtimeIdentifier>win-x64</runtimeIdentifier>
+      </properties>
+      <preprocessableFiles>
+        <file src="Windows.DotNet.Arch\Items.props.mustache"
+              target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.symbols.props" />
+        <file src="Windows.DotNet.Arch\Install.ps1.mustache"
+              target="Windows.DotNet.Arch\Install.{{{platformArchitecture}}}.symbols.ps1" />
+        <file src="Windows.DotNet.Arch\Uninstall.ps1.mustache"
+              target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.symbols.ps1" />
+      </preprocessableFiles>
+    </package>
     <package id="Microsoft.ChakraCore.win-arm" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
       <properties>
         <platformArchitecture>arm</platformArchitecture>
@@ -66,6 +94,20 @@
               target="Windows.DotNet.Arch\Install.{{{platformArchitecture}}}.ps1" />
         <file src="Windows.DotNet.Arch\Uninstall.ps1.mustache"
               target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.ps1" />
+      </preprocessableFiles>
+    </package>
+    <package id="Microsoft.ChakraCore.win-arm.symbols" nuspecFile="Windows.DotNet.Arch\Symbols.nuspec">
+      <properties>
+        <platformArchitecture>arm</platformArchitecture>
+        <runtimeIdentifier>win-arm</runtimeIdentifier>
+      </properties>
+      <preprocessableFiles>
+        <file src="Windows.DotNet.Arch\Items.props.mustache"
+              target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.symbols.props" />
+        <file src="Windows.DotNet.Arch\Install.ps1.mustache"
+              target="Windows.DotNet.Arch\Install.{{{platformArchitecture}}}.symbols.ps1" />
+        <file src="Windows.DotNet.Arch\Uninstall.ps1.mustache"
+              target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.symbols.ps1" />
       </preprocessableFiles>
     </package>
     <package id="Microsoft.ChakraCore.vc140" nuspecFile="Windows.Cpp.All\Primary.nuspec">


### PR DESCRIPTION
Having looked at the [NuGet.org](https://www.nuget.org/) site many packages that contain native assemblies, I did not find a no one package for which symbols were loaded. It seems that for packages with native assemblies, can't create symbol packages in either old (`.symbols.nupkg`) or new (`.snupkg`) format. Therefore, to create a platform-specific “symbol” packages, we will use the same approach as in the `Microsoft.ChakraCore.Symbols` package: create a regular NuGet packages that will deploy the `.pdb` files instead of the `.dll` files.

This PR relates to issue #6586.