### PR TITLE
NuGet: Add a support for Windows (ARM64) platform

### DIFF
--- a/Build/NuGet/Windows.Cpp.All/Items.targets
+++ b/Build/NuGet/Windows.Cpp.All/Items.targets
@@ -2,6 +2,8 @@
 <Project ToolVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemDefinitionGroup>
     <Link>
+      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm64\Debug\ChakraCore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm64\Release\ChakraCore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm'">$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm\Debug\ChakraCore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'arm'">$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm\Release\ChakraCore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\lib\native\v140\x64\Debug\ChakraCore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -13,6 +15,14 @@
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm64'">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm64\Debug\ChakraCore.dll" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm64\Debug\ChakraCore.pdb" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'arm64'">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm64\Release\ChakraCore.dll" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm64\Release\ChakraCore.pdb" />
+  </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm\Debug\ChakraCore.dll" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\native\v140\arm\Debug\ChakraCore.pdb" />

--- a/Build/NuGet/Windows.Cpp.All/Primary.nuspec
+++ b/Build/NuGet/Windows.Cpp.All/Primary.nuspec
@@ -59,6 +59,19 @@
     <file src="..\..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\debug" />
     <file src="..\..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\debug" />
 
+    <file src="..\..\VcBuild\bin\arm64_release\ChakraCore.dll" target="lib\native\v140\arm64\release" />
+    <file src="..\..\VcBuild\bin\arm64_release\ChakraCore.lib" target="lib\native\v140\arm64\release" />
+    <file src="..\..\VcBuild\bin\arm64_release\ChakraCore.pdb" target="lib\native\v140\arm64\release" />
+    <file src="..\..\VcBuild\bin\arm64_release\ch.exe" target="lib\native\v140\arm64\release" />
+    <file src="..\..\VcBuild\bin\arm64_release\ch.pdb" target="lib\native\v140\arm64\release" />
+
+    <!--Copying Release to Debug for now to save on build time-->
+    <file src="..\..\VcBuild\bin\arm64_release\ChakraCore.dll" target="lib\native\v140\arm64\debug" />
+    <file src="..\..\VcBuild\bin\arm64_release\ChakraCore.lib" target="lib\native\v140\arm64\debug" />
+    <file src="..\..\VcBuild\bin\arm64_release\ChakraCore.pdb" target="lib\native\v140\arm64\debug" />
+    <file src="..\..\VcBuild\bin\arm64_release\ch.exe" target="lib\native\v140\arm64\debug" />
+    <file src="..\..\VcBuild\bin\arm64_release\ch.pdb" target="lib\native\v140\arm64\debug" />
+
     $CommonFileElements$
   </files>
 </package>

--- a/Build/NuGet/Windows.DotNet.All/Primary.nuspec
+++ b/Build/NuGet/Windows.DotNet.All/Primary.nuspec
@@ -11,6 +11,7 @@
       <dependency id="Microsoft.ChakraCore.win-x86" version="$version$" />
       <dependency id="Microsoft.ChakraCore.win-x64" version="$version$" />
       <dependency id="Microsoft.ChakraCore.win-arm" version="$version$" />
+      <dependency id="Microsoft.ChakraCore.win-arm64" version="$version$" />
     </dependencies>
   </metadata>
   <files>

--- a/Build/NuGet/Windows.DotNet.All/Symbols.nuspec
+++ b/Build/NuGet/Windows.DotNet.All/Symbols.nuspec
@@ -11,6 +11,7 @@
       <dependency id="Microsoft.ChakraCore.win-x86.symbols" version="$version$" />
       <dependency id="Microsoft.ChakraCore.win-x64.symbols" version="$version$" />
       <dependency id="Microsoft.ChakraCore.win-arm.symbols" version="$version$" />
+      <dependency id="Microsoft.ChakraCore.win-arm64.symbols" version="$version$" />
     </dependencies>
   </metadata>
   <files>

--- a/Build/NuGet/package-data.xml
+++ b/Build/NuGet/package-data.xml
@@ -110,6 +110,34 @@
               target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.symbols.ps1" />
       </preprocessableFiles>
     </package>
+    <package id="Microsoft.ChakraCore.win-arm64" nuspecFile="Windows.DotNet.Arch\Primary.nuspec">
+      <properties>
+        <platformArchitecture>arm64</platformArchitecture>
+        <runtimeIdentifier>win-arm64</runtimeIdentifier>
+      </properties>
+      <preprocessableFiles>
+        <file src="Windows.DotNet.Arch\Items.props.mustache"
+              target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.props" />
+        <file src="Windows.DotNet.Arch\Install.ps1.mustache"
+              target="Windows.DotNet.Arch\Install.{{{platformArchitecture}}}.ps1" />
+        <file src="Windows.DotNet.Arch\Uninstall.ps1.mustache"
+              target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.ps1" />
+      </preprocessableFiles>
+    </package>
+    <package id="Microsoft.ChakraCore.win-arm64.symbols" nuspecFile="Windows.DotNet.Arch\Symbols.nuspec">
+      <properties>
+        <platformArchitecture>arm64</platformArchitecture>
+        <runtimeIdentifier>win-arm64</runtimeIdentifier>
+      </properties>
+      <preprocessableFiles>
+        <file src="Windows.DotNet.Arch\Items.props.mustache"
+              target="Windows.DotNet.Arch\Items.{{{platformArchitecture}}}.symbols.props" />
+        <file src="Windows.DotNet.Arch\Install.ps1.mustache"
+              target="Windows.DotNet.Arch\Install.{{{platformArchitecture}}}.symbols.ps1" />
+        <file src="Windows.DotNet.Arch\Uninstall.ps1.mustache"
+              target="Windows.DotNet.Arch\Uninstall.{{{platformArchitecture}}}.symbols.ps1" />
+      </preprocessableFiles>
+    </package>
     <package id="Microsoft.ChakraCore.vc140" nuspecFile="Windows.Cpp.All\Primary.nuspec">
       <properties>
         <tags>{{{base}}},nativepackage,C++,vc140</tags>


### PR DESCRIPTION
Created the Microsoft.ChakraCore.win-arm64 and Microsoft.ChakraCore.win-arm64.symbols packages, and references to these packages have been added to metapackages as dependencies. In addition, support for the ARM64 processor architecture has been added to the Microsoft.ChakraCore.vc140 package.

This PR relates to issue #6586.