### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,13 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g")
 option(CHAKRACORE_BUILD_SH "Use build.sh")
 
 if(NOT CHAKRACORE_BUILD_SH)
+    option(DISABLE_JIT "Disable JIT compilation" OFF)
     option(INTL_ICU "Enable Intl" ON)
     option(EMBED_ICU "Build ICU within ChakraCore build" OFF)
     set(ICU_INCLUDE_PATH "" CACHE STRING "libicu iclude path")
+    if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+      set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type" FORCE)
+    endif (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 else(NOT CHAKRACORE_BUILD_SH)
 
     # Keep CMake from caching static/shared library

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,27 +17,51 @@ else ()
     set(VARIANT --noJit)
 endif()
 
+# Target to run all tests
+add_custom_target(check)
+
 if (CMAKE_BUILD_TYPE STREQUAL Release)
-    set(TEST_SUITE echo "Running Hello World test" && ${CMAKE_BINARY_DIR}/ch ${CMAKE_CURRENT_SOURCE_DIR}/Basics/hello.js)
+    add_custom_target(smoke-check
+        COMMAND echo "Running Hello World test"
+        COMMAND ${CMAKE_BINARY_DIR}/ch ${CMAKE_CURRENT_SOURCE_DIR}/Basics/hello.js
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        USES_TERMINAL
+        DEPENDS ch
+        )
+    add_dependencies(check smoke-check)
 else()
-    set(BYTE_CODE_CHECK ${CMAKE_CURRENT_SOURCE_DIR}/../tools/regenByteCode.py ${VARIANT} --verify --binary=${CMAKE_BINARY_DIR}/ch)
-    set(TEST_SUITE ${CMAKE_CURRENT_SOURCE_DIR}/runtests.py ${TEST_BUILD_TYPE} ${TEST_ICU} ${TEST_VARIANT} --binary=${CMAKE_BINARY_DIR}/ch)
+    add_custom_target(bytecode-check
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/regenByteCode.py ${VARIANT} --verify --binary=${CMAKE_BINARY_DIR}/ch
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        USES_TERMINAL
+        DEPENDS ch
+        )
+    add_custom_target(regression-check
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/runtests.py ${TEST_BUILD_TYPE} ${TEST_ICU} ${TEST_VARIANT} --binary=${CMAKE_BINARY_DIR}/ch
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        USES_TERMINAL
+        DEPENDS ch
+        )
+    add_dependencies(check bytecode-check regression-check)
 endif()
 
 if (NOT NO_ICU AND NOT EMBED_ICU)
-    set(NATIVE_TEST cd ${CMAKE_CURRENT_SOURCE_DIR}/native-tests && ./test_native.sh ${CMAKE_BINARY_DIR}/ch ${CMAKE_BUILD_TYPE} ${CMAKE_C_COMPILER} ${CMAKE_CXX_COMPILER} ${CMAKE_SOURCE_DIR})
+    add_custom_target(native-check
+        COMMAND ./test_native.sh ${CMAKE_BINARY_DIR}/ch ${CMAKE_BUILD_TYPE} ${CMAKE_C_COMPILER} ${CMAKE_CXX_COMPILER} ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/native-tests
+        USES_TERMINAL
+        DEPENDS ch
+        )
+    add_dependencies(check native-check)
 else()
-    set(NATIVE_TEST echo "Native tests NOT RUN, they require ICU to be installed not embedded. NO_ICU = ${NO_ICU} EMBED_ICU = ${EMBED_ICU}")
+    set(ICU_MESSAGE "Native tests are DISABLED, as they require ICU to be installed, and not embedded. NO_ICU = ${NO_ICU} EMBED_ICU = ${EMBED_ICU}")
+    message(WARNING ${ICU_MESSAGE})
+    add_custom_target(warn-icu-tests
+        COMMAND echo "${ICU_MESSAGE}"
+        USES_TERMINAL
+        )
+    add_dependencies(check warn-icu-tests)
 endif()
-
-add_custom_target(check
-    COMMAND ${BYTE_CODE_CHECK}
-    COMMAND ${TEST_SUITE}
-    COMMAND ${NATIVE_TEST}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    USES_TERMINAL
-    DEPENDS ch
-    )
 
 if (NOT STATIC_LIBRARY)
     add_dependencies(check ChakraCore)


### PR DESCRIPTION
Make `DISABLE_JIT` an official CMake option and set default build type. Split test target into multiple sub-targets.