### PR TITLE
 NuGet: Add a support for .NET Framework Client Profiles in MSBuild scripts

### DIFF
--- a/Build/NuGet/Windows.DotNet.Arch/Items.props.mustache
+++ b/Build/NuGet/Windows.DotNet.Arch/Items.props.mustache
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition=" '$(TargetFramework)' == '' Or '$(TargetFramework.TrimEnd(`0123456789`))' == 'net' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == '' Or $([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '\d+(?:\-client)?$', '', System.Text.RegularExpressions.RegexOptions.IgnoreCase)) == 'net' ">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\{{runtimeIdentifier}}\native\*.*" Condition=" '$(Platform)' == 'AnyCPU' ">
       <Link>{{platformArchitecture}}\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Unfortunately, current implementation of MSBuild scripts does not support the following target frameworks: `net35-client` and `net40-client`.

Therefore, I had to complicate the condition a little.

Before:

```
'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'
```

After:

```
$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '\d+(?:\-client)?$', '', System.Text.RegularExpressions.RegexOptions.IgnoreCase)) == 'net'
```

This PR is a bit related to issue #6572.