### PR TITLE
Add support for Visual Studio 2022

### DIFF
--- a/Build/Common.Build.Default.props
+++ b/Build/Common.Build.Default.props
@@ -18,6 +18,7 @@
     <PlatformToolset Condition="'$(BuildToolVersion)'=='14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(BuildToolVersion)'=='15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(BuildToolVersion)'=='16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(BuildToolVersion)'=='17.0'">v143</PlatformToolset>
   </PropertyGroup>
 
   <!-- Default ChakraDevConfigDir -->


### PR DESCRIPTION
Many developers, including me, have already uninstalled VS2019 and completely switched to VS2022.