### PR TITLE
Fix incorrect failFast for Incr0

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "Backend.h"
@@ -2364,7 +2365,10 @@ GlobOpt::CollectMemOpInfo(IR::Instr *instrBegin, IR::Instr *instr, Value *src1Va
             // Line #2: s3(s1) = Ld_A   s4(s2)
             // do not consider line #2 as a violating instr
             (instr->m_opcode == Js::OpCode::Ld_I4 &&
-                prevInstr && (prevInstr->m_opcode == Js::OpCode::Add_I4 || prevInstr->m_opcode == Js::OpCode::Sub_I4) &&
+                // note Ld_A is for the case where the add was 0
+                prevInstr && (prevInstr->m_opcode == Js::OpCode::Add_I4 ||
+                              prevInstr->m_opcode == Js::OpCode::Sub_I4 ||
+                              prevInstr->m_opcode == Js::OpCode::Ld_A   ) &&
                 instr->GetSrc1()->IsRegOpnd() &&
                 instr->GetDst()->IsRegOpnd() &&
                 prevInstr->GetDst()->IsRegOpnd() &&

--- a/test/loop/MemOpIncr0.js
+++ b/test/loop/MemOpIncr0.js
@@ -1,0 +1,11 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+for (let v3 = -65537; v3 < 3; v3 = v3 + 0) {
+    const v4 = v3++;
+}
+
+print("pass");

--- a/test/loop/rlexe.xml
+++ b/test/loop/rlexe.xml
@@ -60,4 +60,9 @@
       <baseline>MemOp.baseline</baseline>
     </default>
   </test>
+    <test>
+    <default>
+      <files>MemOpIncr0.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
This was a simple incorrect FailFast the existing logic accounted for `v = v + x` or `v = v - x` for any integer `x` except for 0 - adjusted to allow for 0.

The existing logic falsely saw the optimised code produced from `v = v + 0` in the increment section of a loop control as invalid code hence aborted.

Fixes #6763