### PR TITLE
[CI] Temporarily switch to windows-2019 image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,7 @@ jobs:
   - job: MSVC
     timeoutInMinutes: 120
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
     strategy:
       maxParallel: 4
       matrix:


### PR DESCRIPTION
`windows-latest`, aka `windows-2022` does not work well with our detection of msbuild path. Temporarily pick 2019 to get CI builds unstuck.