### PR TITLE
Exclude dependabot from agreement check

### DIFF
--- a/.github/workflows/agreement.yml
+++ b/.github/workflows/agreement.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   AgreementCheck:
     runs-on: ubuntu-latest
-    if: github.actor != "dependabot[bot]"
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/agreement.yml
+++ b/.github/workflows/agreement.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   AgreementCheck:
     runs-on: ubuntu-latest
+    if: github.actor != "dependabot[bot]"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/agreement.yml
+++ b/.github/workflows/agreement.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   AgreementCheck:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Exclude dependabot from Contribution Agreement check. Hopefully we don't have to do this for multiple bots. This is how Github recommends detecting it:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions