### PR TITLE
Stop checking for 2021

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) Microsoft Corporation
 All rights reserved.
-Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+Copyright (c) ChakraCore Project Contributors. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tools/StyleChecks/check_copyright.py
+++ b/tools/StyleChecks/check_copyright.py
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
-# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Copyright (c) ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
@@ -14,7 +14,7 @@ import re
 copyright_lines = [
     r'-------------------------------------------------------------------------------------------------------',
     r' Copyright \(C\) Microsoft( Corporation and contributors)?\. All rights reserved\.',
-    r' Copyright \(c\) 2021 ChakraCore Project Contributors\. All rights reserved\.',
+    r' Copyright \(c\)( 2022)? ChakraCore Project Contributors\. All rights reserved\.',
     r' Licensed under the MIT license\. See LICENSE\.txt file in the project root for full license information\.',
     r'.*' # the above should always be followed by at least one other line, so make sure that line is present
 ]


### PR DESCRIPTION
Our copyright check script was enforcing the placement of "2021" in copyright headers - I've removed this, giving an option of 2022 or no year. (ShortDevelopment's PR 6838 is failing the check for saying 2022)

Similarly remove 2021 from the license - the microsoft copyright didn't have a year not sure why we added it.

@ppenzin this ok?