### PR TITLE
NuGet: Update copyrights in PowerShell scripts

### DIFF
--- a/Build/NuGet/Windows.DotNet.Arch/Install.ps1.mustache
+++ b/Build/NuGet/Windows.DotNet.Arch/Install.ps1.mustache
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
-# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Copyright (c) ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 

--- a/Build/NuGet/Windows.DotNet.Arch/Uninstall.ps1.mustache
+++ b/Build/NuGet/Windows.DotNet.Arch/Uninstall.ps1.mustache
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
-# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Copyright (c) ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 

--- a/Build/NuGet/package-classes.psm1
+++ b/Build/NuGet/package-classes.psm1
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
-# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Copyright (c) ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 

--- a/Build/NuGet/package.ps1
+++ b/Build/NuGet/package.ps1
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
-# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Copyright (c) ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Remove a copyright year form NuGet PowerShell scripts.