### PR TITLE
Allow `undefined` in `TypedArray.prototype.sort(comparefn)`

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -183,7 +183,6 @@ RT_ERROR_MSG(JSERR_FunctionArgument_Invalid, 5065, "%s: invalid argument", "Inva
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedObject, 5066, "%s: argument is not an Object", "Object expected", kjstTypeError, JSERR_NeedObject)
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedInternalObject, 5067, "%s: argument is not a JavaScript object", "JavaScript object expected", kjstTypeError, JSERR_NeedInternalObj)
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedFunction, 5068, "%s: argument is not a Function object", "Function expected", kjstTypeError, JSERR_NeedFunction)
-RT_ERROR_MSG(JSERR_FunctionArgument_NeedFunctionOrUndefined, 7301, "%s: argument is neither a Function object nor undefined", "Function expected", kjstTypeError, JSERR_NeedFunction)
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedVBArray, 5069, "%s: argument is not a VBArray object", "VBArray expected", kjstTypeError, JSERR_NeedVBArray)
 RT_ERROR_MSG(JSERR_FunctionArgument_NullOrUndefined, 5070, "%s: argument is null or undefined", "Object expected", kjstTypeError, JSERR_NeedObject)
 RT_ERROR_MSG(JSERR_FunctionArgument_NotObjectOrNull, 5071, "%s: argument is not an Object and is not null", "Object expected", kjstTypeError, JSERR_NeedObject)
@@ -425,5 +424,3 @@ RT_ERROR_MSG(WABTERR_WabtError, 7200, "%s", "Wabt Error.", kjstTypeError, 0)
 
 // Implicit Conversion Errors
 RT_ERROR_MSG(JSERR_ImplicitStrConv, 7300, "No implicit conversion of %s to String", "Cannot implicitly convert to String", kjstTypeError, 0)
-
-// 7301 - JSERR_FunctionArgument_NeedFunctionOrUndefined

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -183,6 +183,7 @@ RT_ERROR_MSG(JSERR_FunctionArgument_Invalid, 5065, "%s: invalid argument", "Inva
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedObject, 5066, "%s: argument is not an Object", "Object expected", kjstTypeError, JSERR_NeedObject)
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedInternalObject, 5067, "%s: argument is not a JavaScript object", "JavaScript object expected", kjstTypeError, JSERR_NeedInternalObj)
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedFunction, 5068, "%s: argument is not a Function object", "Function expected", kjstTypeError, JSERR_NeedFunction)
+RT_ERROR_MSG(JSERR_FunctionArgument_NeedFunctionOrUndefined, 7301, "%s: argument is neither a Function object nor undefined", "Function expected", kjstTypeError, JSERR_NeedFunction)
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedVBArray, 5069, "%s: argument is not a VBArray object", "VBArray expected", kjstTypeError, JSERR_NeedVBArray)
 RT_ERROR_MSG(JSERR_FunctionArgument_NullOrUndefined, 5070, "%s: argument is null or undefined", "Object expected", kjstTypeError, JSERR_NeedObject)
 RT_ERROR_MSG(JSERR_FunctionArgument_NotObjectOrNull, 5071, "%s: argument is not an Object and is not null", "Object expected", kjstTypeError, JSERR_NeedObject)
@@ -424,3 +425,5 @@ RT_ERROR_MSG(WABTERR_WabtError, 7200, "%s", "Wabt Error.", kjstTypeError, 0)
 
 // Implicit Conversion Errors
 RT_ERROR_MSG(JSERR_ImplicitStrConv, 7300, "No implicit conversion of %s to String", "Cannot implicitly convert to String", kjstTypeError, 0)
+
+// 7301 - JSERR_FunctionArgument_NeedFunctionOrUndefined

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -2263,11 +2263,11 @@ namespace Js
 
         RecyclableObject* compareFn = nullptr;
 
-        if (args.Info.Count > 1)
+        if (args.Info.Count > 1 && !JavascriptOperators::IsUndefined(args[1]))
         {
             if (!JavascriptConversion::IsCallable(args[1]))
             {
-                JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedFunction, _u("[TypedArray].prototype.sort"));
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedFunctionOrUndefined, _u("[TypedArray].prototype.sort"));
             }
 
             compareFn = VarTo<RecyclableObject>(args[1]);

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) 2022 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 // Implementation for typed arrays based on ArrayBuffer.

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -2267,7 +2267,7 @@ namespace Js
         {
             if (!JavascriptConversion::IsCallable(args[1]))
             {
-                JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedFunctionOrUndefined, _u("[TypedArray].prototype.sort"));
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedFunction, _u("[TypedArray].prototype.sort"));
             }
 
             compareFn = VarTo<RecyclableObject>(args[1]);

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -435,4 +435,9 @@ Below test fails with difference in space. Investigate the cause and re-enable t
       <files>definitetypedarray.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>sort.js</files>
+    </default>
+  </test>
 </regress-exe>

--- a/test/typedarray/sort.js
+++ b/test/typedarray/sort.js
@@ -1,0 +1,12 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2022 ChakraCore Project Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+const array = new Uint32Array([3, 1, 2]);
+
+// May not throw; See https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort
+array.sort(undefined);
+
+print("pass");


### PR DESCRIPTION
According to the spec, `TypedArray.prototype.sort(comparefn)` should allow `comparefn` to be `undefined`.

In this case `.sort(undefined)` should be equivalent to `.sort()`.
See https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort

Before it threw a `TypeError`.

@rhuanjl 

Fix #6503