### PR TITLE
`Date` ctr spec compliance

### DIFF
--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -950,10 +950,9 @@ CommonNumber:
 
     double JavascriptConversion::ToInteger(double val)
     {
-        if(JavascriptNumber::IsNan(val) || val == -0 || val == 0)
+        if(JavascriptNumber::IsNan(val) || JavascriptNumber::IsZero(val))
             return 0;
-        if(JavascriptNumber::IsPosInf(val) || JavascriptNumber::IsNegInf(val) ||
-            JavascriptNumber::IsZero(val))
+        if(JavascriptNumber::IsPosInf(val) || JavascriptNumber::IsNegInf(val))
         {
             return val;
         }

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -949,7 +949,7 @@ CommonNumber:
 
     double JavascriptConversion::ToInteger(double val)
     {
-        if(JavascriptNumber::IsNan(val))
+        if(JavascriptNumber::IsNan(val) || val == -0 || val == 0)
             return 0;
         if(JavascriptNumber::IsPosInf(val) || JavascriptNumber::IsNegInf(val) ||
             JavascriptNumber::IsZero(val))

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2022 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLanguagePch.h"

--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) 2022 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"

--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -2513,39 +2513,6 @@ DEFINE_ISXLOCALEAVAILABLE(PR, uloc)
     }
 
 #ifdef INTL_ICU
-    // Implementation of ECMA 262 #sec-timeclip
-    // REVIEW(jahorto): Where is a better place for this function? JavascriptDate? DateUtilities? JavascriptConversion?
-    static double TimeClip(Var x)
-    {
-        double time = 0.0;
-        if (TaggedInt::Is(x))
-        {
-            time = TaggedInt::ToDouble(x);
-        }
-        else
-        {
-            AssertOrFailFast(JavascriptNumber::Is(x));
-            time = JavascriptNumber::GetValue(x);
-
-            // Only perform steps 1, 3, and 4 if the input was not a TaggedInt, since TaggedInts cant be infinite or -0
-            if (!NumberUtilities::IsFinite(time))
-            {
-                return NumberConstants::NaN;
-            }
-
-            // This performs both steps 3 and 4
-            time = JavascriptConversion::ToInteger(time);
-        }
-
-        // Step 2: If abs(time) > 8.64e15, return NaN.
-        if (Math::Abs(time) > 8.64e15)
-        {
-            return NumberConstants::NaN;
-        }
-
-        return time;
-    }
-
     static void AddPartToPartsArray(ScriptContext *scriptContext, JavascriptArray *arr, int arrIndex, const char16 *src, int start, int end, JavascriptString *partType)
     {
         JavascriptString *partValue = JavascriptString::NewCopyBuffer(
@@ -2640,7 +2607,7 @@ DEFINE_ISXLOCALEAVAILABLE(PR, uloc)
 
         // 1. Let x be TimeClip(x)
         // 2. If x is NaN, throw a RangeError exception
-        double date = TimeClip(args[2]);
+        double date = JavascriptDate::TimeClip(args[2]);
         if (JavascriptNumber::IsNan(date))
         {
             JavascriptError::ThrowRangeError(scriptContext, JSERR_InvalidDate);

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -163,8 +163,8 @@ namespace Js
                     timeValue = JavascriptConversion::ToNumber(value, scriptContext);
                 }
             }
-
-            timeValue = TimeClip(JavascriptNumber::ToVar(timeValue));
+            
+            timeValue = TimeClip(JavascriptNumber::New(timeValue, scriptContext));
 
             pDate->m_date.SetTvUtc(timeValue);
             return pDate;

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -219,7 +219,6 @@ namespace Js
     }
 
     // Implementation of ECMA 262 #sec-timeclip
-    // REVIEW(jahorto): Where is a better place for this function? JavascriptDate? DateUtilities? JavascriptConversion?
     double JavascriptDate::TimeClip(Var x)
     {
         double time = 0.0;

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2022 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
@@ -161,6 +162,11 @@ namespace Js
                 {
                     timeValue = JavascriptConversion::ToNumber(value, scriptContext);
                 }
+            }
+
+            if (timeValue == -0)
+            {
+                timeValue = 0;
             }
 
             pDate->m_date.SetTvUtc(timeValue);

--- a/lib/Runtime/Library/JavascriptDate.h
+++ b/lib/Runtime/Library/JavascriptDate.h
@@ -127,6 +127,7 @@ namespace Js
         static Var EntryUTC(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntryValueOf(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntrySymbolToPrimitive(RecyclableObject* function, CallInfo callInfo, ...);
+        static double JavascriptDate::TimeClip(Var x);
 
         static JavascriptString* ToLocaleString(JavascriptDate* date, ScriptContext* requestContext);
         static JavascriptString* ToString(JavascriptDate* date, ScriptContext* requestContext);

--- a/lib/Runtime/Library/JavascriptDate.h
+++ b/lib/Runtime/Library/JavascriptDate.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2022 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once

--- a/test/Date/DateCtr.js
+++ b/test/Date/DateCtr.js
@@ -59,6 +59,11 @@ function Test()
     d = new Date("", 1e81); if (!CHECK(d + "")) return; // WOOB 1139099
     d = new Date(); d.setSeconds(Number.MAX_VALUE); if (!CHECK(d + "")) return;  // WOOB 1142298
     d = new Date(); d.setSeconds(-Number.MAX_VALUE); if (!CHECK(d + "")) return; // WOOB 1142298
+
+    // Issue #5442
+    d = new Date(-0);
+    if (!Object.is(d.getTime(), 0)) throw new Error("Expected getTime() to return +0");
+
     console.log("PASS");
 }
 

--- a/test/Date/DateCtr.js
+++ b/test/Date/DateCtr.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) 2022 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
According to the [spec](https://tc39.es/ecma262/#sec-date-value), the `Date` ctr should use the [`TimeClip` function](https://tc39.es/ecma262/#sec-timeclip).
Since it did not, `-0` was not converted to `+0` in the ctr (See issue #5442).

The ctr now uses `JavascriptDate::TimeClip` (moved from `IntlEngineInterfaceExtensionObject.cpp`).
However, this does not fix the original issue, as the underlying `JavascriptConversion::ToInteger` function is also [not spec compliant](https://tc39.es/ecma262/#sec-tointegerorinfinity) regarding the conversion from `-0` to `+0`.

This [non-compliance](https://tc39.es/ecma262/#sec-toint32) is also true for the other `ToIntXX` and `ToUintXX` functions (Not covered by this PR).

`JavascriptDate::TimeClip` should perhaps be placed somewhere else...

@rhuanjl (Could you please tag this PR with `hacktoberfest-accepted`?)

Fix #5442
Related to https://github.com/chakra-core/ChakraCore/pull/6743