### PR TITLE
Fix pathological BailOut for chakraLibrary.isArray

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft Corporation and contributors. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) 2022 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -1707,6 +1707,7 @@ namespace Js
         JsBuiltInEngineInterfaceExtensionObject* builtInExtension = RecyclerNew(recycler, JsBuiltInEngineInterfaceExtensionObject, scriptContext);
         engineInterfaceObject->SetEngineExtension(EngineInterfaceExtensionKind_JsBuiltIn, builtInExtension);
         this->isArrayFunction = this->DefaultCreateFunction(&JavascriptArray::EntryInfo::IsArray, 1, nullptr, nullptr, PropertyIds::isArray);
+        builtinFuncs[BuiltinFunction::JavascriptArray_IsArray] = this->isArrayFunction;
 #endif
 
 #endif
@@ -1902,7 +1903,6 @@ namespace Js
         library->AddMember(arrayConstructor, PropertyIds::name, scriptContext->GetPropertyString(PropertyIds::Array), PropertyConfigurable);
 
 #ifdef ENABLE_JS_BUILTINS
-        builtinFuncs[BuiltinFunction::JavascriptArray_IsArray] = library->isArrayFunction;
         library->AddMember(arrayConstructor, PropertyIds::isArray, library->isArrayFunction);
 #else
         library->AddFunctionToLibraryObject(arrayConstructor, PropertyIds::isArray, &JavascriptArray::EntryInfo::IsArray, 1);

--- a/lib/Runtime/Library/JsBuiltInEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/JsBuiltInEngineInterfaceExtensionObject.cpp
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) 2022 ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
@@ -135,21 +135,17 @@ namespace Js
             // Clear ReentrancyLock bit as initialization code doesn't have any side effect
             scriptContext->GetThreadContext()->SetNoJsReentrancy(false);
 #endif
+            // specify which set of BuiltIns are currently being loaded
+            current = file;
+
             // Clear disable implicit call bit as initialization code doesn't have any side effect
             {
                 ThreadContext::AutoRestoreImplicitFlags autoRestoreImplicitFlags(scriptContext->GetThreadContext(), scriptContext->GetThreadContext()->GetImplicitCallFlags(), scriptContext->GetThreadContext()->GetDisableImplicitFlags());
                 scriptContext->GetThreadContext()->ClearDisableImplicitFlags();
                 JavascriptFunction::CallRootFunctionInScript(functionGlobal, Js::Arguments(callInfo, args));
-            }
 
-            Js::ScriptFunction *functionBuiltins = scriptContext->GetLibrary()->CreateScriptFunction(jsBuiltInByteCode->GetNestedFunctionForExecution(0));
-            functionBuiltins->SetPrototype(scriptContext->GetLibrary()->nullValue);
-
-            current = file;
-            // Clear disable implicit call bit as initialization code doesn't have any side effect
-            {
-                ThreadContext::AutoRestoreImplicitFlags autoRestoreImplicitFlags(scriptContext->GetThreadContext(), scriptContext->GetThreadContext()->GetImplicitCallFlags(), scriptContext->GetThreadContext()->GetDisableImplicitFlags());
-                scriptContext->GetThreadContext()->ClearDisableImplicitFlags();
+                Js::ScriptFunction *functionBuiltins = scriptContext->GetLibrary()->CreateScriptFunction(jsBuiltInByteCode->GetNestedFunctionForExecution(0));
+                functionBuiltins->SetPrototype(scriptContext->GetLibrary()->nullValue);
                 JavascriptFunction::CallRootFunctionInScript(functionBuiltins, Js::Arguments(callInfo, args));
             }
 


### PR DESCRIPTION
In #6583 I re-factored JsBuiltin logic and enabled separate loading of Math, Array and Object builtins. However in doing so I introduced a bug. Depending on the order you loaded the builtins it was possible to inline __chakraLibrary.isArray without the correct `JavascriptLibrary::builtinFuncs` array value being set.

Fix this by setting it when initialising the JavascriptLibrary rather than when the Array Constructor is first initialised (which could happen too late) Setting this upon Library initialisation ensures that it is set before any use of isArray can occur.

**No test case included**
I couldn't think of a good way to test this - the failure is if a particular bailout type occurs. Run this snippet with `-trace:bailout` with master to see ~90,000 bailouts occur and run with this fix to see less than 20 bailouts.
```js
const arr = [...Array(10000).keys()];

for (const item of arr) { 
  const a = Math.round(item/3); 
}
```


Fix: #6819 