### PR TITLE
Throw `TypeError` on `Object.assign` with readonly property

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLanguagePch.h"
@@ -2712,6 +2712,12 @@ CommonNumber:
         {
             if ((flags & Accessor) == Accessor)
             {
+                if (IsUndefinedAccessor(setterValueOrProxy, requestContext))
+                {
+                    JavascriptError::ThrowCantAssign(propertyOperationFlags, requestContext, propertyId);
+                    *result = TRUE;
+                    return true;
+                }
                 if (JavascriptError::ThrowIfStrictModeUndefinedSetter(propertyOperationFlags, setterValueOrProxy, requestContext) ||
                     JavascriptError::ThrowIfNotExtensibleUndefinedSetter(propertyOperationFlags, setterValueOrProxy, requestContext))
                 {

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2712,9 +2712,9 @@ CommonNumber:
         {
             if ((flags & Accessor) == Accessor)
             {
-                if (IsUndefinedAccessor(setterValueOrProxy, requestContext))
+                if (IsUndefinedAccessor(setterValueOrProxy, requestContext)
+                    && JavascriptError::ThrowCantAssign(propertyOperationFlags, requestContext, propertyId))
                 {
-                    JavascriptError::ThrowCantAssign(propertyOperationFlags, requestContext, propertyId);
                     *result = TRUE;
                     return true;
                 }

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2712,14 +2712,7 @@ CommonNumber:
         {
             if ((flags & Accessor) == Accessor)
             {
-                if (IsUndefinedAccessor(setterValueOrProxy, requestContext)
-                    && JavascriptError::ThrowCantAssign(propertyOperationFlags, requestContext, propertyId))
-                {
-                    *result = TRUE;
-                    return true;
-                }
-                if (JavascriptError::ThrowIfStrictModeUndefinedSetter(propertyOperationFlags, setterValueOrProxy, requestContext) ||
-                    JavascriptError::ThrowIfNotExtensibleUndefinedSetter(propertyOperationFlags, setterValueOrProxy, requestContext))
+                if (JavascriptError::ThrowIfUndefinedSetter(propertyOperationFlags, setterValueOrProxy, requestContext, propertyId))
                 {
                     *result = TRUE;
                     return true;

--- a/lib/Runtime/Library/JavascriptError.cpp
+++ b/lib/Runtime/Library/JavascriptError.cpp
@@ -758,6 +758,34 @@ namespace Js
         return false;
     }
 
+    bool JavascriptError::ThrowIfUndefinedSetter(
+        PropertyOperationFlags flags, Var setterValue, ScriptContext* scriptContext, PropertyId propertyId)
+    {
+        if (!JavascriptOperators::IsUndefinedAccessor(setterValue, scriptContext))
+            return false;
+
+        bool shouldThrow = scriptContext->GetThreadContext()->RecordImplicitException();
+        if (flags & PropertyOperation_StrictMode)
+        {
+            if (shouldThrow)
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_CantAssignToReadOnly);
+            return true;
+        }
+        else if (flags & PropertyOperation_ThrowIfNotExtensible)
+        {
+            if (shouldThrow)
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_DefineProperty_NotExtensible);
+            return true;
+        }
+        else if (flags & PropertyOperation_ThrowIfNonWritable)
+        {
+            if (shouldThrow)
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_DefineProperty_NotWritable, scriptContext->GetPropertyName(propertyId)->GetBuffer());
+            return true;
+        }
+        return false;
+    }
+
     bool JavascriptError::ThrowIfStrictModeUndefinedSetter(
         PropertyOperationFlags flags, Var setterValue, ScriptContext* scriptContext)
     {

--- a/lib/Runtime/Library/JavascriptError.cpp
+++ b/lib/Runtime/Library/JavascriptError.cpp
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"

--- a/lib/Runtime/Library/JavascriptError.h
+++ b/lib/Runtime/Library/JavascriptError.h
@@ -118,6 +118,7 @@ namespace Js
         static bool ThrowCantExtendIfStrictMode(PropertyOperationFlags flags, ScriptContext* scriptContext);
         static bool ThrowCantDeleteIfStrictMode(PropertyOperationFlags flags, ScriptContext* scriptContext, PCWSTR varName);
         static bool ThrowCantDeleteIfStrictModeOrNonconfigurable(PropertyOperationFlags flags, ScriptContext* scriptContext, PCWSTR varName);
+        static bool ThrowIfUndefinedSetter(PropertyOperationFlags flags, Var setterValue, ScriptContext* scriptContext, PropertyId propertyId);
         static bool ThrowIfStrictModeUndefinedSetter(PropertyOperationFlags flags, Var setterValue, ScriptContext* scriptContext);
         static bool ThrowIfNotExtensibleUndefinedSetter(PropertyOperationFlags flags, Var setterValue, ScriptContext* scriptContext);
 

--- a/lib/Runtime/Library/JavascriptError.h
+++ b/lib/Runtime/Library/JavascriptError.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once

--- a/test/Object/assign.js
+++ b/test/Object/assign.js
@@ -1,7 +1,11 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+
+// @ts-check
+/// <reference path="..\UnitTestFramework\UnitTestFramework.js" />
 
 WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
@@ -149,6 +153,15 @@ var tests = [
             assert.areEqual(newObj.a, orig.a);
             assert.areEqual(newObj[0], orig[0]);
             assert.areEqual(newObj[1], undefined);
+        }
+    },
+    {
+        name: "Throw on assign to read-only",
+        body() {
+            const obj = {
+                get prop() { return 1; }
+            };
+            assert.throws(() => Object.assign(obj, obj), TypeError, "Object.assign should throw (readonly property)");
         }
     }
 ];


### PR DESCRIPTION
Assigning values to read-only properties via `Object.assign` should throw a `TypeError` but it didn't.
https://tc39.es/ecma262/#sec-set-o-p-v-throw

I'm not sure if / in how fare this problem could exist for similar apis.

@rhuanjl 

Fix #6523