### PR TITLE
`SyntaxError` on statement without body

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -3761,7 +3761,7 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
             goto LUnknown;
         }
         this->GetScanner()->Scan();
-        ParseStatement<buildAST>(true);
+        ParseStatement<buildAST>();
         break;
 #endif
 
@@ -9845,7 +9845,7 @@ ParseNodeTry * Parser::ParseTry()
     }
 
     PushStmt<buildAST>(&stmt, pnode, knopTry, nullptr);
-    ParseNodePtr pnodeBody = ParseStatement<buildAST>(true);
+    ParseNodePtr pnodeBody = ParseStatement<buildAST>();
     if (buildAST)
     {
         pnode->pnodeBody = pnodeBody;
@@ -9873,7 +9873,7 @@ ParseNodeFinally * Parser::ParseFinally()
     }
 
     PushStmt<buildAST>(&stmt, pnode, knopFinally, nullptr);
-    ParseNodePtr pnodeBody = ParseStatement<buildAST>(true);
+    ParseNodePtr pnodeBody = ParseStatement<buildAST>();
     if (buildAST)
     {
         pnode->pnodeBody = pnodeBody;
@@ -10035,7 +10035,7 @@ ParseNodeCatch * Parser::ParseCatch()
             Error(ERRnoLcurly);
         }
 
-        ParseNodePtr pnodeBody = ParseStatement<buildAST>(true);  //catch(id[:expr]) {block}
+        ParseNodePtr pnodeBody = ParseStatement<buildAST>();  //catch(id[:expr]) {block}
         if (buildAST)
         {
             pnode->pnodeBody = pnodeBody;
@@ -10102,7 +10102,7 @@ ParseNodeCase * Parser::ParseCase(ParseNodePtr *ppnodeBody)
 Parse a single statement. Digest a trailing semicolon.
 ***************************************************************************/
 template<bool buildAST>
-ParseNodePtr Parser::ParseStatement(bool parseBody)
+ParseNodePtr Parser::ParseStatement()
 {
     ParseNodePtr pnode = nullptr;
     LabelId* pLabelIdList = nullptr;
@@ -10170,17 +10170,9 @@ LRestart:
     {
     case tkEOF:
         if (labelledStatement)
-        {
             Error(ERRLabelFollowedByEOF);
-        }
-        if (parseBody)
-        {
+        else
             Error(ERRsyntaxEOF);
-        }
-        if (buildAST)
-        {
-            pnode = nullptr;
-        }
         break;
 
     case tkFUNCTION:
@@ -10534,7 +10526,7 @@ LRestart:
                 TrackAssignment<true>(pnodeT, nullptr);
             }
             PushStmt<buildAST>(&stmt, pnodeForInOrForOf, isForAwait ? knopForAwaitOf : (isForOf ? knopForOf : knopForIn), pLabelIdList);
-            ParseNodePtr pnodeBody = ParseStatement<buildAST>(true);
+            ParseNodePtr pnodeBody = ParseStatement<buildAST>();
 
             if (buildAST)
             {
@@ -10595,7 +10587,7 @@ LRestart:
                 pnodeFor->ichLim = ichLim;
             }
             PushStmt<buildAST>(&stmt, pnodeFor, knopFor, pLabelIdList);
-            ParseNodePtr pnodeBody = ParseStatement<buildAST>(true);
+            ParseNodePtr pnodeBody = ParseStatement<buildAST>();
             if (buildAST)
             {
                 pnodeFor->pnodeBody = pnodeBody;
@@ -10741,7 +10733,7 @@ LRestart:
         bool stashedDisallowImportExportStmt = m_disallowImportExportStmt;
         m_disallowImportExportStmt = true;
         PushStmt<buildAST>(&stmt, pnodeWhile, knopWhile, pLabelIdList);
-        ParseNodePtr pnodeBody = ParseStatement<buildAST>(true);
+        ParseNodePtr pnodeBody = ParseStatement<buildAST>();
         PopStmt(&stmt);
 
         if (buildAST)
@@ -10764,7 +10756,7 @@ LRestart:
         this->GetScanner()->Scan();
         bool stashedDisallowImportExportStmt = m_disallowImportExportStmt;
         m_disallowImportExportStmt = true;
-        ParseNodePtr pnodeBody = ParseStatement<buildAST>(true);
+        ParseNodePtr pnodeBody = ParseStatement<buildAST>();
         m_disallowImportExportStmt = stashedDisallowImportExportStmt;
         PopStmt(&stmt);
         charcount_t ichMinT = this->GetScanner()->IchMinTok();
@@ -10829,12 +10821,12 @@ LRestart:
         bool stashedDisallowImportExportStmt = m_disallowImportExportStmt;
         m_disallowImportExportStmt = true;
         PushStmt<buildAST>(&stmt, pnodeIf, knopIf, pLabelIdList);
-        ParseNodePtr pnodeTrue = ParseStatement<buildAST>(true);
+        ParseNodePtr pnodeTrue = ParseStatement<buildAST>();
         ParseNodePtr pnodeFalse = nullptr;
         if (m_token.tk == tkELSE)
         {
             this->GetScanner()->Scan();
-            pnodeFalse = ParseStatement<buildAST>(true);
+            pnodeFalse = ParseStatement<buildAST>();
         }
         if (buildAST)
         {
@@ -10923,7 +10915,7 @@ LRestart:
         PushBlockInfo(CreateBlockNode());
         PushDynamicBlock();
 
-        ParseNodePtr pnodeBody = ParseStatement<buildAST>(true);
+        ParseNodePtr pnodeBody = ParseStatement<buildAST>();
         if (buildAST)
         {
             pnode->AsParseNodeWith()->pnodeBody = pnodeBody;

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1810,7 +1810,7 @@ void Parser::FinishParseBlock(ParseNodeBlock *pnodeBlock, bool needScanRCurly)
         // have been set already.
         pnodeBlock->ichLim = this->GetScanner()->IchLimTok();
     }
-    
+
     BindPidRefs<false>(GetCurrentBlockInfo(), m_nextBlockId - 1);
 
     PopStmt(&m_currentBlockInfo->pstmt);

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -794,7 +794,7 @@ private:
 
     template<bool buildAST> ParseNodeArrLit * ParseArrayLiteral();
 
-    template<bool buildAST> ParseNodePtr ParseStatement();
+    template<bool buildAST> ParseNodePtr ParseStatement(bool parseBody = false);
     template<bool buildAST> ParseNodePtr ParseVariableDeclaration(
         tokens declarationType,
         charcount_t ichMin,

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -794,7 +794,7 @@ private:
 
     template<bool buildAST> ParseNodeArrLit * ParseArrayLiteral();
 
-    template<bool buildAST> ParseNodePtr ParseStatement(bool parseBody = false);
+    template<bool buildAST> ParseNodePtr ParseStatement();
     template<bool buildAST> ParseNodePtr ParseVariableDeclaration(
         tokens declarationType,
         charcount_t ichMin,

--- a/lib/Parser/perrors.h
+++ b/lib/Parser/perrors.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 // parser error messages

--- a/lib/Parser/perrors.h
+++ b/lib/Parser/perrors.h
@@ -8,6 +8,7 @@
 
 LSC_ERROR_MSG(1001, ERRnoMemory      , "Out of memory")
 LSC_ERROR_MSG(1002, ERRsyntax        , "Syntax error")
+LSC_ERROR_MSG(1104, ERRsyntaxEOF     , "Unexpected end of script.")
 LSC_ERROR_MSG(1003, ERRnoColon       , "Expected ':'")
 LSC_ERROR_MSG(1004, ERRnoSemic       , "Expected ';'")
 LSC_ERROR_MSG(1005, ERRnoLparen      , "Expected '('")
@@ -116,7 +117,9 @@ LSC_ERROR_MSG(1100, ERRUndeclaredExportName, "Export of name '%s' which has no l
 LSC_ERROR_MSG(1101, ERRModuleImportOrExportInScript, "'import' or 'export' can only be used in module code.")
 LSC_ERROR_MSG(1102, ERRInvalidAsgTarget, "Invalid left-hand side in assignment.")
 LSC_ERROR_MSG(1103, ERRMissingFrom, "Expected 'from' after import or export clause.")
-//1104-1199 available for future use
+
+// 1104 ERRsyntaxEOF
+// 1105-1199 available for future use
 
 // Generic errors intended to be re-usable
 LSC_ERROR_MSG(1200, ERRKeywordAfter, "Unexpected keyword '%s' after '%s'")

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -1,241 +1,243 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+
+// @ts-check
+/// <reference path="..\UnitTestFramework\UnitTestFramework.js" />
 
 WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
 var tests = [
-  {
-    name: "calling Symbol.toPrimitive on Date prototype should not AV",
-    body: function () {
-         Date.prototype[Symbol.toPrimitive].call({},'strin' + 'g');
-    }
-  },
-  {
-    name: "updated stackTraceLimit should not fire re-entrancy assert",
-    body: function () {
-        Error.__defineGetter__('stackTraceLimit', function () { return 1;});
-        assert.throws(()=> Array.prototype.map.call([]));
-    }
-  },
-  {
-    name: "Array.prototype.slice should not fire re-entrancy error when the species returns proxy",
-    body: function () {
-        let arr = [1, 2];
-        arr.__proto__ = {
-          constructor: {
-            [Symbol.species]: function () {
-              return new Proxy({}, {
-                defineProperty(...args) {
-                  return Reflect.defineProperty(...args);
+    {
+        name: "calling Symbol.toPrimitive on Date prototype should not AV",
+        body: function () {
+            Date.prototype[Symbol.toPrimitive].call({}, 'strin' + 'g');
+        }
+    },
+    {
+        name: "updated stackTraceLimit should not fire re-entrancy assert",
+        body: function () {
+            Error.__defineGetter__('stackTraceLimit', function () { return 1; });
+            assert.throws(() => Array.prototype.map.call([]));
+        }
+    },
+    {
+        name: "Array.prototype.slice should not fire re-entrancy error when the species returns proxy",
+        body: function () {
+            let arr = [1, 2];
+            arr.__proto__ = {
+                constructor: {
+                    [Symbol.species]: function () {
+                        return new Proxy({}, {
+                            defineProperty(...args) {
+                                return Reflect.defineProperty(...args);
+                            }
+                        });
+                    }
                 }
-              });
             }
-          }
+            Array.prototype.slice.call(arr);
         }
-        Array.prototype.slice.call(arr);
-    }
-  },
-  {
-    name: "rest param under eval with arguments usage in the body should not fail assert",
-    body: function () {
-        f();
-        function f() {
-            eval("function bar(...x){arguments;}")
-        }
-    }
-  },
-  {
-    name: "Token left after parsing lambda result to the syntax error",
-    body: function () {
-        assert.throws(()=> { eval('function foo ([ [] = () => { } = {a2:z2}]) { };'); });
-    }
-  },
-  {
-    name: "Token left after parsing lambda in ternary operator should not throw",
-    body: function () {
-        assert.doesNotThrow(()=> { eval('function foo () {  true ? e => {} : 1};'); });
-    }
-  },
-  {
-    name: "ArrayBuffer.slice with proxy constructor should not fail fast",
-    body: function () {
-      let arr = new ArrayBuffer(10);
-      arr.constructor = new Proxy(ArrayBuffer, {});
-      
-      arr.slice(1,2);
-    }
-  },
-  {
-    name: "Large proxy chain should not cause IsConstructor to crash on stack overflow",
-    body: function () {
-      let p = new Proxy(Object, {});
-      for (let  i=0; i<20000; ++i)
-      {
-          p = new Proxy(p, {});
-      }
-      try
-      {
-          let a = new p();
-      }
-      catch(e)
-      {
-      }
-    }
-  },
-  {
-    name: "splice an array which has getter/setter at 4294967295 should not fail due to re-entrancy error",
-    body: function () {
-        var base = 4294967290;
-        var arr = [];
-        for (var i = 0; i < 10; i++) {
-            arr[base + i] = 100 + i;
-        }
-        Object.defineProperty(arr, 4294967295, {
-          get: function () { }, set : function(b) {  }
+    },
+    {
+        name: "rest param under eval with arguments usage in the body should not fail assert",
+        body: function () {
+            f();
+            function f() {
+                eval("function bar(...x){arguments;}")
             }
-        );
+        }
+    },
+    {
+        name: "Token left after parsing lambda result to the syntax error",
+        body: function () {
+            assert.throws(() => { eval('function foo ([ [] = () => { } = {a2:z2}]) { };'); });
+        }
+    },
+    {
+        name: "Token left after parsing lambda in ternary operator should not throw",
+        body: function () {
+            assert.doesNotThrow(() => { eval('function foo () {  true ? e => {} : 1};'); });
+        }
+    },
+    {
+        name: "ArrayBuffer.slice with proxy constructor should not fail fast",
+        body: function () {
+            let arr = new ArrayBuffer(10);
+            arr.constructor = new Proxy(ArrayBuffer, {});
 
-        assert.throws(()=> {arr.splice(4294967290, 0, 200, 201, 202, 203, 204, 205, 206);});
-    }
-  },
-  {
-    name: "Passing args count near 2**16 should not fire assert (OS# 17406027)",
-    body: function () {
-      try {
-        eval.call(...(new Array(2**16)));
-      } catch (e) { }
-      
-      try {
-        eval.call(...(new Array(2**16+1)));
-      } catch (e) { }
-      
-      try {
-        var sc1 = WScript.LoadScript(`function foo() {}`, "samethread");
-        sc1.foo(...(new Array(2**16)));
-      } catch(e) { }
-      
-      try {
-        var sc2 = WScript.LoadScript(`function foo() {}`, "samethread");
-        sc2.foo(...(new Array(2**16+1)));
-      } catch(e) { }
+            arr.slice(1, 2);
+        }
+    },
+    {
+        name: "Large proxy chain should not cause IsConstructor to crash on stack overflow",
+        body: function () {
+            let p = new Proxy(Object, {});
+            for (let i = 0; i < 20000; ++i) {
+                p = new Proxy(p, {});
+            }
+            try {
+                let a = new p();
+            }
+            catch (e) {
+            }
+        }
+    },
+    {
+        name: "splice an array which has getter/setter at 4294967295 should not fail due to re-entrancy error",
+        body: function () {
+            var base = 4294967290;
+            var arr = [];
+            for (var i = 0; i < 10; i++) {
+                arr[base + i] = 100 + i;
+            }
+            Object.defineProperty(arr, 4294967295, {
+                get: function () { }, set: function (b) { }
+            }
+            );
 
-      try {
-        function foo() {}
-        Reflect.construct(foo, new Array(2**16-3));
-      } catch(e) { }
+            assert.throws(() => { arr.splice(4294967290, 0, 200, 201, 202, 203, 204, 205, 206); });
+        }
+    },
+    {
+        name: "Passing args count near 2**16 should not fire assert (OS# 17406027)",
+        body: function () {
+            try {
+                eval.call(...(new Array(2 ** 16)));
+            } catch (e) { }
 
-      try {
-        function foo() {}
-        Reflect.construct(foo, new Array(2**16-2));
-      } catch(e) { }
+            try {
+                eval.call(...(new Array(2 ** 16 + 1)));
+            } catch (e) { }
 
-      try {
-        function foo() {}
-        var bar = foo.bind({}, 1);
-        new bar(...(new Array(2**16+1)))
-      } catch(e) { }
-    }
-  },
-  {
-    name: "Using RegExp as newTarget should not assert",
-    body: function() {
-      var v0 = function() { this.a; };
-      var v1 = class extends v0 { constructor() { super(); } };
-      Reflect.construct(v1, [], RegExp);
-    }
-  },
-  {
-    name: "getPrototypeOf Should not be called when set as prototype",
-    body: function () {
-      var p = new Proxy({}, { getPrototypeOf: function() {
-          assert.fail("this should not be called")
-          return {};
-        }});
+            try {
+                var sc1 = WScript.LoadScript(`function foo() {}`, "samethread");
+                sc1.foo(...(new Array(2 ** 16)));
+            } catch (e) { }
 
-        var obj = {};
-        obj.__proto__ = p; // This should not call the getPrototypeOf
+            try {
+                var sc2 = WScript.LoadScript(`function foo() {}`, "samethread");
+                sc2.foo(...(new Array(2 ** 16 + 1)));
+            } catch (e) { }
 
-        var obj1 = {};
-        Object.setPrototypeOf(obj1, p); // This should not call the getPrototypeOf
+            try {
+                function foo() { }
+                Reflect.construct(foo, new Array(2 ** 16 - 3));
+            } catch (e) { }
 
-        var obj2 = {__proto__ : p}; // This should not call the getPrototypeOf
-    }
-  },
-  {
-    name: "Cross-site activation object",
-    body: function () {
-        var tests = [0, 0];  
-        tests.forEach(function() {
-            var eval = WScript.LoadScript(0, "samethread").eval;
-            eval(0);
-        });
-    }
-  },
-  {
-    name: "Destructuring declaration should return undefined",
-    body: function () {
-        assert.areEqual(undefined, eval("var {x} = {};"));
-        assert.areEqual(undefined, eval("let {x,y} = {};"));
-        assert.areEqual(undefined, eval("const [z] = [];"));
-        assert.areEqual(undefined, eval("let {x} = {}, y = 1, {z} = {};"));
-        assert.areEqual([1], eval("let {x} = {}; [x] = [1]"));
-    }
-  },
-  {
-    name: "Strict Mode : throw type error when the handler returns falsy value",
-    body: function () {
-        assert.throws(() => {"use strict"; let p1 = new Proxy({}, { set() {}}); p1.foo = 1;}, TypeError, "returning undefined on set handler is return false which will throw type error",  "Proxy set handler returned false");
-        assert.throws(() => {"use strict"; let p1 = new Proxy({}, { deleteProperty() {}}); delete p1.foo;}, TypeError, "returning undefined on deleteProperty handler is return false which will throw type error",  "Proxy deleteProperty handler returned false");
-        assert.throws(() => {"use strict"; let p1 = new Proxy({}, { set() {return false;}}); p1.foo = 1;}, TypeError, "set handler is returning false which will throw type error",  "Proxy set handler returned false");
-        assert.throws(() => {"use strict"; let p1 = new Proxy({}, { deleteProperty() {return false;}}); delete p1.foo;}, TypeError, "deleteProperty handler is returning false which will throw type error",  "Proxy deleteProperty handler returned false");
-      }
-  },
-  {
-    name: "Generator : testing recursion",
-    body: function () {
-        // This will throw out of stack error
-        assert.throws(() => {
-            function foo() {
-                function *f() {
-                    yield foo();
+            try {
+                function foo() { }
+                Reflect.construct(foo, new Array(2 ** 16 - 2));
+            } catch (e) { }
+
+            try {
+                function foo() { }
+                var bar = foo.bind({}, 1);
+                new bar(...(new Array(2 ** 16 + 1)))
+            } catch (e) { }
+        }
+    },
+    {
+        name: "Using RegExp as newTarget should not assert",
+        body: function () {
+            var v0 = function () { this.a; };
+            var v1 = class extends v0 { constructor() { super(); } };
+            Reflect.construct(v1, [], RegExp);
+        }
+    },
+    {
+        name: "getPrototypeOf Should not be called when set as prototype",
+        body: function () {
+            var p = new Proxy({}, {
+                getPrototypeOf: function () {
+                    assert.fail("this should not be called")
+                    return {};
                 }
-                f().next();
-            }
-            foo();
-        });
-      }
-  },
-  {
-    name: "destructuring : testing recursion",
-    body: function () {
-      try {
-        eval(`
+            });
+
+            var obj = {};
+            obj.__proto__ = p; // This should not call the getPrototypeOf
+
+            var obj1 = {};
+            Object.setPrototypeOf(obj1, p); // This should not call the getPrototypeOf
+
+            var obj2 = { __proto__: p }; // This should not call the getPrototypeOf
+        }
+    },
+    {
+        name: "Cross-site activation object",
+        body: function () {
+            var tests = [0, 0];
+            tests.forEach(function () {
+                var eval = WScript.LoadScript(0, "samethread").eval;
+                eval(0);
+            });
+        }
+    },
+    {
+        name: "Destructuring declaration should return undefined",
+        body: function () {
+            assert.areEqual(undefined, eval("var {x} = {};"));
+            assert.areEqual(undefined, eval("let {x,y} = {};"));
+            assert.areEqual(undefined, eval("const [z] = [];"));
+            assert.areEqual(undefined, eval("let {x} = {}, y = 1, {z} = {};"));
+            assert.areEqual([1], eval("let {x} = {}; [x] = [1]"));
+        }
+    },
+    {
+        name: "Strict Mode : throw type error when the handler returns falsy value",
+        body: function () {
+            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { set() { } }); p1.foo = 1; }, TypeError, "returning undefined on set handler is return false which will throw type error", "Proxy set handler returned false");
+            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { deleteProperty() { } }); delete p1.foo; }, TypeError, "returning undefined on deleteProperty handler is return false which will throw type error", "Proxy deleteProperty handler returned false");
+            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { set() { return false; } }); p1.foo = 1; }, TypeError, "set handler is returning false which will throw type error", "Proxy set handler returned false");
+            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { deleteProperty() { return false; } }); delete p1.foo; }, TypeError, "deleteProperty handler is returning false which will throw type error", "Proxy deleteProperty handler returned false");
+        }
+    },
+    {
+        name: "Generator : testing recursion",
+        body: function () {
+            // This will throw out of stack error
+            assert.throws(() => {
+                function foo() {
+                    function* f() {
+                        yield foo();
+                    }
+                    f().next();
+                }
+                foo();
+            });
+        }
+    },
+    {
+        name: "destructuring : testing recursion",
+        body: function () {
+            try {
+                eval(`
             var ${'['.repeat(6631)}
           `);
-          assert.fail();
-        }
-        catch (e) {
-        }
-        
-        try {
-            eval(`
+                assert.fail();
+            }
+            catch (e) {
+            }
+
+            try {
+                eval(`
                var {${'a:{'.repeat(6631)}
             `);
-            assert.fail();
+                assert.fail();
+            }
+            catch (e) {
+            }
         }
-        catch (e) {
-        }
-      }
-  },
-  {
-    name: "CrossSite issue while array concat OS: 18874745",
-    body: function () {
-          function test0() {
-            var IntArr0 = Array();
-            var sc0Code = `
+    },
+    {
+        name: "CrossSite issue while array concat OS: 18874745",
+        body: function () {
+            function test0() {
+                var IntArr0 = Array();
+                var sc0Code = `
               Object.defineProperty(Array, Symbol.species, { value : function() {
                       return IntArr0;
                       }
@@ -248,80 +250,102 @@ var tests = [
               test({}, [1]);
             }
             `;
-            var sc0 = WScript.LoadScript(sc0Code, 'samethread');
-            sc0.IntArr0 = IntArr0;
-            sc0.out();
-          }
-         test0();
-      }
-  },
-  {
-    name: "Init box javascript array : OS : 20517662",
-    body: function () {
-      var obj = {};
-      obj[0] = 11;
-      obj[1] = {};
-      obj[17] = 222;
-      obj[35] = 333; // This is will increase the size past the inline segment
-      
-      Object.assign({}, obj); // The InitBoxedInlineSegments will be called due to this call.
-    }
-  },
-  {
-    name: "calling promise's function as constructor should not be allowed",
-    body: function () {
-        var var_0 = new Promise(function () {});                                           
-        var var_1 = function () {};                                                        
-                                                                                          
-        var_0.then = function (a, b) {                                                     
-          var_2 = b;                                                                       
-        };                                                                                 
-        var_3 = Promise.prototype.finally.call(var_0, var_1);                              
-        assert.throws(() => { new var_2([]).var_3(); },TypeError);
-      }
-  },
-  {
-    name: "issue : 6174 : calling ToNumber for the fill value for typedarray.prototype.fill",
-    body: function () {
-        let arr1 = new Uint32Array(5);
-        let valueOfCalled = false;
-        let p1 = new Proxy([], {
-            get: function(oTarget, sKey) {
-                if (sKey.toString() == 'valueOf') {
-                    valueOfCalled = true;
-                }
-                return Reflect.get(oTarget, sKey);
+                var sc0 = WScript.LoadScript(sc0Code, 'samethread');
+                sc0.IntArr0 = IntArr0;
+                sc0.out();
             }
-        });
-        Uint32Array.prototype.fill.call(arr1, p1, 5, 1);
-        assert.isTrue(valueOfCalled);
-    }
-  },
-  {
-    name: "class name should not change if calling multiple times",
-    body: function () {
-        function getClass() {
-          class A {
-            constructor() {
-
-            }
-          };
-          return A;
+            test0();
         }
-        let f1 = getClass();
-        let f2 = getClass();
-        let f3 = getClass();
-        assert.areEqual("A", f1.name);
-        assert.areEqual("A", f2.name);
-        assert.areEqual("A", f3.name);
-      }
-  },
-  {
-    name: "should throw syntax error when expression within if is comma-terminated",
-    body: function () {
-        assert.throws(()=> { eval('var f = function () { var f = 0; if (f === 0,) print("run_here"); }; f();'); }, SyntaxError);
-      }
-  }
+    },
+    {
+        name: "Init box javascript array : OS : 20517662",
+        body: function () {
+            var obj = {};
+            obj[0] = 11;
+            obj[1] = {};
+            obj[17] = 222;
+            obj[35] = 333; // This is will increase the size past the inline segment
+
+            Object.assign({}, obj); // The InitBoxedInlineSegments will be called due to this call.
+        }
+    },
+    {
+        name: "calling promise's function as constructor should not be allowed",
+        body: function () {
+            var var_0 = new Promise(function () { });
+            var var_1 = function () { };
+
+            var_0.then = function (a, b) {
+                var_2 = b;
+            };
+            var_3 = Promise.prototype.finally.call(var_0, var_1);
+            assert.throws(() => { new var_2([]).var_3(); }, TypeError);
+        }
+    },
+    {
+        name: "issue : 6174 : calling ToNumber for the fill value for typedarray.prototype.fill",
+        body: function () {
+            let arr1 = new Uint32Array(5);
+            let valueOfCalled = false;
+            let p1 = new Proxy([], {
+                get: function (oTarget, sKey) {
+                    if (sKey.toString() == 'valueOf') {
+                        valueOfCalled = true;
+                    }
+                    return Reflect.get(oTarget, sKey);
+                }
+            });
+            Uint32Array.prototype.fill.call(arr1, p1, 5, 1);
+            assert.isTrue(valueOfCalled);
+        }
+    },
+    {
+        name: "class name should not change if calling multiple times",
+        body: function () {
+            function getClass() {
+                class A {
+                    constructor() {
+
+                    }
+                };
+                return A;
+            }
+            let f1 = getClass();
+            let f2 = getClass();
+            let f3 = getClass();
+            assert.areEqual("A", f1.name);
+            assert.areEqual("A", f2.name);
+            assert.areEqual("A", f3.name);
+        }
+    },
+    {
+        name: "should throw syntax error when expression within if is comma-terminated",
+        body: function () {
+            assert.throws(() => { eval('var f = function () { var f = 0; if (f === 0,) print("run_here"); }; f();'); }, SyntaxError);
+        }
+    },
+    {
+        name: "Correct parsing of (missing) expression bodies",
+        body() {
+            assert.throws(() => eval("if(true)"), SyntaxError);
+            assert.doesNotThrow(() => eval("if(true);"));
+            assert.doesNotThrow(() => eval("if(true){}"));
+
+            assert.throws(() => eval("if(true){}else"), SyntaxError);
+            assert.doesNotThrow(() => eval("if(true){}else;"));
+            assert.doesNotThrow(() => eval("if(true){}else{}"));
+
+            assert.throws(() => eval("while(false)"), SyntaxError);
+            assert.doesNotThrow(() => eval("while(false);"));
+            assert.doesNotThrow(() => eval("while(false){}"));
+
+            assert.throws(() => eval("for(;false;)"), SyntaxError);
+            assert.doesNotThrow(() => eval("for(;false;);"));
+            assert.doesNotThrow(() => eval("for(;false;){}"));
+
+            assert.throws(() => eval("do"), SyntaxError);
+        }
+    }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
According to the [Rules of Automatic Semicolon Insertion](https://tc39.es/ecma262/#sec-rules-of-automatic-semicolon-insertion):
> a semicolon is never inserted automatically if the semicolon would then be parsed as an empty statement

Therefore, a poc like in #6351 should throw (inside `eval` and outside).
But CC didn't handle the (unexpected) "end of the input stream" as a `SyntaxError`.
This applies to `if`, `for`, `while`, `do`, ...

---

The parser retrieves the body of such a statement like so:
https://github.com/chakra-core/ChakraCore/blob/0a9c0822d88bf2dd032b6a7c96d41105ba595f9d/lib/Parser/Parse.cpp#L10594

The `tkEOF` case (inside `Parser::ParseStatement`) is only hit, if it is unexpected:
https://github.com/chakra-core/ChakraCore/blob/0a9c0822d88bf2dd032b6a7c96d41105ba595f9d/lib/Parser/Parse.cpp#L10169-L10180
In such a case, CC should always throw, even if `labelledStatement == false`.

---

@rhuanjl 

Fix #6351
Fix #6553 (Closed as duplicate)
Fix #5128

Report to tc39: https://github.com/tc39/test262/issues/2661