### PR TITLE
Fix build race detected by vcpkg.

### DIFF
--- a/lib/SCACore/Chakra.SCACore.vcxproj
+++ b/lib/SCACore/Chakra.SCACore.vcxproj
@@ -60,6 +60,9 @@
     <ClInclude Include="StreamReader.h" />
     <ClInclude Include="StreamWriter.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../../manifests/CoreManifests.vcxproj" />
+  </ItemGroup>
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.targets" Condition="exists('$(BuildConfigPropsPath)Chakra.Build.targets')" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
In https://dev.azure.com/vcpkg/public/_build/results?buildId=80997 , we observe this error:

```
       "D:\buildtrees\chakracore\x86-windows\Build\Chakra.Core.sln" (Rebuild target) (1) ->
       "D:\buildtrees\chakracore\x86-windows\lib\SCACore\Chakra.SCACore.vcxproj" (Rebuild target) (35) ->
       (ClCompile target) ->
         D:\buildtrees\chakracore\x86-windows\lib\Common\Core\EtwTraceCore.h(81,10): fatal  error C1083: Cannot open include file: 'Microsoft-Scripting-Chakra-InstrumentationEvents.h': No such file or directory [D:\buildtrees\chakracore\x86-windows\lib\SCACore\Chakra.SCACore.vcxproj]
```

It appears that this is supposed to be a generated header file, but there's no obvious dependency from Chakra.SCACore.vcxproj on CoreManifests.vcxproj which seems to produce that file.