### PR TITLE
[C++20/DR] Fix compile error for equality in rewrite expressions

### DIFF
--- a/lib/Runtime/Language/SimdUtils.h
+++ b/lib/Runtime/Language/SimdUtils.h
@@ -45,7 +45,7 @@ struct _SIMDValue
     {
         f64[SIMD_X] = f64[SIMD_Y] = 0;
     }
-    bool operator==(const _SIMDValue& r)
+    bool operator==(const _SIMDValue& r) const
     {
         // don't compare f64/f32 because NaN bit patterns will not be considered equal.
         return (this->i32[SIMD_X] == r.i32[SIMD_X] &&


### PR DESCRIPTION
After the MSVC team implemented [P2468R2 The Equality Operator You Are Looking For](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2468r2.html), we got an error compiling ChakraCore with /std:c++latest on MSVC, now it is fixed.

Error message:
`F:\gitP\microsoft\ChakraCore\lib\Runtime\Language\SimdUtils.h(70,16): error C2666: '_SIMDValue::operator ==': overloaded functions have similar conversions`
`F:\gitP\microsoft\ChakraCore\lib\Runtime\Language\SimdUtils.h(48,10): note: could be 'bool _SIMDValue::operator ==(const _SIMDValue &)'`
`C:\Program Files (x86)\Windows Kits\10\include\10.0.22618.0\shared\guiddef.h(192,15): note: or       'bool operator ==(const GUID &,const GUID &)'`
`F:\gitP\microsoft\ChakraCore\lib\Runtime\Language\SimdUtils.h(48,10): note: or 'bool _SIMDValue::operator ==(const _SIMDValue &)' [synthesized expression 'y == x']`
`C:\Program Files (x86)\Windows Kits\10\include\10.0.22618.0\shared\guiddef.h(192,15): note: or 'bool operator ==(const GUID &,const GUID &)' [synthesized expression 'y == x']`
`F:\gitP\microsoft\ChakraCore\lib\Runtime\Language\SimdUtils.h(70,16): note: while trying to match the argument list '(_SIMDValue, _SIMDValue)'`