### PR TITLE
Use `.editorconfig` to help with code style consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+# See https://github.com/chakra-core/ChakraCore/wiki/Coding-Convention
+
+[*]
+indent_style = space
+indent_size = 4
+
+# See https://learn.microsoft.com/en-us/visualstudio/ide/cpp-editorconfig-properties?view=vs-2019
+[*.{cpp,h,inl}]
+cpp_space_pointer_reference_alignment = right
+cpp_new_line_before_open_brace_block = new_line
+cpp_new_line_before_catch = true
+cpp_new_line_before_else = true
+
+# Xml files
+[*.xml]
+indent_size = 2

--- a/Build/Chakra.Core.sln
+++ b/Build/Chakra.Core.sln
@@ -168,6 +168,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Chakra.ICU.Stubdata", "..\d
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Chakra.SCACore", "..\lib\SCACore\Chakra.SCACore.vcxproj", "{4DA3A367-6ED2-4EE8-9698-5BCD0B8AF7F5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "EditorConfig", "EditorConfig", "{9EAC0ED9-9EC0-492E-975B-92CA3FE527C8}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM

--- a/tools/StyleChecks/check_copyright.sh
+++ b/tools/StyleChecks/check_copyright.sh
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
-# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Copyright (c) ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
@@ -42,6 +42,7 @@ git diff --name-only `git merge-base origin/master HEAD` HEAD |
     grep -v -E '\.json$' |
     grep -v -E '\.man$' |
     grep -v -E '\.testconfig$' |
+	grep -v -E '\.editorconfig$' |
     grep -v -E '\.proj$' |
     grep -v -E '\.png$' |
     grep -v -E 'packages.config$' |

--- a/tools/StyleChecks/check_copyright.sh
+++ b/tools/StyleChecks/check_copyright.sh
@@ -42,7 +42,7 @@ git diff --name-only `git merge-base origin/master HEAD` HEAD |
     grep -v -E '\.json$' |
     grep -v -E '\.man$' |
     grep -v -E '\.testconfig$' |
-	grep -v -E '\.editorconfig$' |
+    grep -v -E '\.editorconfig$' |
     grep -v -E '\.proj$' |
     grep -v -E '\.png$' |
     grep -v -E 'packages.config$' |


### PR DESCRIPTION
As I am used to using the Visual Studio auto formatter, I always had massiv changes in git, as the default code style does not always match the one used in the CC code base.

Therefore I thought it might be useful having a basic `.editorconfig` file to let editors like VS know how to format.

One big problem was the placement of the pointer asterisk.
The code bases uses different approaches:
 - `int* a;`
 - `int *a;`
 - `int * a;`

One other thing was the indentation in the test `*.xml` manifest files...

I tried to stick to the [CC Coding Conventions](https://github.com/chakra-core/ChakraCore/wiki/Coding-Convention).

@rhuanjl What do you think?
