### PR TITLE
Throw `TypeError` if `[[DefineOwnProperty]]` returns false

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -371,7 +371,7 @@ RT_ERROR_MSG(JSERR_InvalidIteratorObject, 5672, "%s : Invalid iterator object", 
 RT_ERROR_MSG(JSERR_NoAccessors, 5673, "Invalid property descriptor: accessors not supported on this object", "", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_RegExpInvalidEscape, 5674, "", "Invalid regular expression: invalid escape in unicode pattern", kjstSyntaxError, 0)
 RT_ERROR_MSG(JSERR_RegExpTooManyCapturingGroups, 5675, "", "Regular expression cannot have more than 32,767 capturing groups", kjstRangeError, 0)
-RT_ERROR_MSG(JSERR_ProxyHandlerReturnedFalse, 5676, "Proxy %s handler returned false", "Proxy handler returned false", kjstTypeError, 0)
+RT_ERROR_MSG(JSERR_ProxyHandlerReturnedFalse, 5676, "Proxy '%s' handler returned falsish for property '%s'", "Proxy handler returned false", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_UnicodeRegExpRangeContainsCharClass, 5677, "%s", "Character classes not allowed in a RegExp class range.", kjstSyntaxError, 0)
 RT_ERROR_MSG(JSERR_DuplicateKeysFromOwnPropertyKeys, 5678, "%s", "Proxy's ownKeys trap returned duplicate keys", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_InvalidGloFuncDecl, 5679, "The global property %s is not configurable, writable, nor enumerable, therefore cannot be declared as a function", "", kjstTypeError, 0)

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft Corporation and contributors. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #define IDS_COMPILATION_ERROR_SOURCE    4096

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -9101,14 +9101,14 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
     // Return value:
     // - TRUE = success.
     // - FALSE (can throw depending on throwOnError parameter) = unsuccessful.
-    BOOL JavascriptOperators::DefineOwnPropertyDescriptor(RecyclableObject* obj, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* scriptContext)
+    BOOL JavascriptOperators::DefineOwnPropertyDescriptor(RecyclableObject* obj, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* scriptContext, PropertyOperationFlags flags /*  = Js::PropertyOperation_None */)
     {
         Assert(obj);
         Assert(scriptContext);
 
         if (VarIs<JavascriptProxy>(obj))
         {
-            return JavascriptProxy::DefineOwnPropertyDescriptor(obj, propId, descriptor, throwOnError, scriptContext);
+            return JavascriptProxy::DefineOwnPropertyDescriptor(obj, propId, descriptor, throwOnError, scriptContext, flags);
         }
 #ifdef _CHAKRACOREBUILD
         else if (VarIs<CustomExternalWrapperObject>(obj))

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -612,7 +612,7 @@ namespace Js
         static Var FromPropertyDescriptor(const PropertyDescriptor& descriptor, ScriptContext* scriptContext);
         static void CompletePropertyDescriptor(PropertyDescriptor* resultDescriptor, PropertyDescriptor* likePropertyDescriptor, ScriptContext* requestContext);
         static BOOL SetPropertyDescriptor(RecyclableObject* object, PropertyId propId, const PropertyDescriptor& descriptor);
-        static BOOL DefineOwnPropertyDescriptor(RecyclableObject* object, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* scriptContext);
+        static BOOL DefineOwnPropertyDescriptor(RecyclableObject* object, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* scriptContext, PropertyOperationFlags flags = Js::PropertyOperation_None);
         static BOOL DefineOwnPropertyForArray(JavascriptArray* arr, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* scriptContext);
 
         static BOOL DefineOwnPropertyForTypedArray(TypedArrayBase * typedArray, PropertyId propId, const PropertyDescriptor & descriptor, bool throwOnError, ScriptContext * scriptContext);

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -2178,7 +2178,7 @@ BOOL JavascriptObject::DefineOwnPropertyHelper(RecyclableObject* obj, PropertyId
         // TODO: implement DefineOwnProperty for other object built-in exotic types.
         else
         {
-            returnValue = JavascriptOperators::DefineOwnPropertyDescriptor(obj, propId, descriptor, throwOnError, scriptContext);
+            returnValue = JavascriptOperators::DefineOwnPropertyDescriptor(obj, propId, descriptor, throwOnError, scriptContext, Js::PropertyOperation_StrictMode);
             if (propId == PropertyIds::__proto__)
             {
                 scriptContext->GetLibrary()->GetObjectPrototypeObject()->PostDefineOwnProperty__proto__(obj);

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
@@ -1349,7 +1349,11 @@ Var JavascriptObject::EntryDefineProperty(RecyclableObject* function, CallInfo c
         ModifyGetterSetterFuncName(propertyRecord, propertyDescriptor, scriptContext);
     }
 
-    DefineOwnPropertyHelper(obj, propertyRecord->GetPropertyId(), propertyDescriptor, scriptContext);
+    BOOL success = DefineOwnPropertyHelper(obj, propertyRecord->GetPropertyId(), propertyDescriptor, scriptContext);
+    if (!success)
+    {
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_DefineProperty_Default, scriptContext->GetPropertyName(propertyRecord->GetPropertyId())->GetBuffer());
+    }
 
     return obj;
 }

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -827,7 +827,12 @@ namespace Js
         {
             if (flags & PropertyOperation_StrictMode)
             {
-                JavascriptError::ThrowTypeError(requestContext, JSERR_ProxyHandlerReturnedFalse, _u("deleteProperty"));
+                JavascriptError::ThrowTypeErrorVar(
+                    requestContext, 
+                    JSERR_ProxyHandlerReturnedFalse, 
+                    _u("deleteProperty"),
+                    threadContext->GetPropertyName(propertyId)->GetBuffer()
+                );
             }
             return trapResult;
         }
@@ -1752,10 +1757,19 @@ namespace Js
         });
 
         BOOL defineResult = JavascriptConversion::ToBoolean(definePropertyResult, requestContext);
-        if (!defineResult)
-        {
-            return defineResult;
-        }
+		if (!defineResult)
+		{
+			if (throwOnError /* ToDo: && flags & PropertyOperation_StrictMode*/)
+			{
+				JavascriptError::ThrowTypeErrorVar(
+					requestContext,
+					JSERR_ProxyHandlerReturnedFalse,
+					_u("defineProperty"),
+					requestContext->GetPropertyName(propId)->GetBuffer()
+				);
+			}
+			return defineResult;
+		}
 
         //12. Let extensibleTarget be ? IsExtensible(target).
         //13. If Desc has a[[Configurable]] field and if Desc.[[Configurable]] is false, then
@@ -1882,15 +1896,19 @@ namespace Js
         });
 
         BOOL setResult = JavascriptConversion::ToBoolean(setPropertyResult, requestContext);
-        if (!setResult)
-        {
-            if (propertyOperationFlags & PropertyOperation_StrictMode)
-            {
-                JavascriptError::ThrowTypeError(requestContext, JSERR_ProxyHandlerReturnedFalse, _u("set"));
-            }
-
-            return setResult;
-        }
+		if (!setResult)
+		{
+			if (propertyOperationFlags & PropertyOperation_StrictMode)
+			{
+				JavascriptError::ThrowTypeErrorVar(
+					requestContext,
+					JSERR_ProxyHandlerReturnedFalse,
+					_u("set"),
+					requestContext->GetPropertyName(propertyId)->GetBuffer()
+				);
+			}
+			return setResult;
+		}
 
         //12. Let targetDesc be the result of calling the[[GetOwnProperty]] internal method of target with argument P.
         //13. ReturnIfAbrupt(targetDesc).

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -1757,19 +1757,19 @@ namespace Js
         });
 
         BOOL defineResult = JavascriptConversion::ToBoolean(definePropertyResult, requestContext);
-		if (!defineResult)
-		{
-			if (throwOnError && flags & PropertyOperation_StrictMode)
-			{
-				JavascriptError::ThrowTypeErrorVar(
-					requestContext,
-					JSERR_ProxyHandlerReturnedFalse,
-					_u("defineProperty"),
-					requestContext->GetPropertyName(propId)->GetBuffer()
-				);
-			}
-			return defineResult;
-		}
+        if (!defineResult)
+        {
+            if (throwOnError && flags & PropertyOperation_StrictMode)
+            {
+                JavascriptError::ThrowTypeErrorVar(
+                    requestContext,
+                    JSERR_ProxyHandlerReturnedFalse,
+                    _u("defineProperty"),
+                    requestContext->GetPropertyName(propId)->GetBuffer()
+                );
+            }
+            return defineResult;
+        }
 
         //12. Let extensibleTarget be ? IsExtensible(target).
         //13. If Desc has a[[Configurable]] field and if Desc.[[Configurable]] is false, then
@@ -1896,19 +1896,19 @@ namespace Js
         });
 
         BOOL setResult = JavascriptConversion::ToBoolean(setPropertyResult, requestContext);
-		if (!setResult)
-		{
-			if (propertyOperationFlags & PropertyOperation_StrictMode)
-			{
-				JavascriptError::ThrowTypeErrorVar(
-					requestContext,
-					JSERR_ProxyHandlerReturnedFalse,
-					_u("set"),
-					requestContext->GetPropertyName(propertyId)->GetBuffer()
-				);
-			}
-			return setResult;
-		}
+        if (!setResult)
+        {
+            if (propertyOperationFlags & PropertyOperation_StrictMode)
+            {
+                JavascriptError::ThrowTypeErrorVar(
+                    requestContext,
+                    JSERR_ProxyHandlerReturnedFalse,
+                    _u("set"),
+                    requestContext->GetPropertyName(propertyId)->GetBuffer()
+                );
+            }
+            return setResult;
+        }
 
         //12. Let targetDesc be the result of calling the[[GetOwnProperty]] internal method of target with argument P.
         //13. ReturnIfAbrupt(targetDesc).

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 //  Implements JavascriptProxy.

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -70,7 +70,7 @@ namespace Js
         static JavascriptProxy* Create(ScriptContext* scriptContext, Arguments args);
 
         static BOOL GetOwnPropertyDescriptor(RecyclableObject* obj, PropertyId propertyId, ScriptContext* requestContext, PropertyDescriptor* propertyDescriptor);
-        static BOOL DefineOwnPropertyDescriptor(RecyclableObject* obj, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* requestContext);
+        static BOOL DefineOwnPropertyDescriptor(RecyclableObject* obj, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* requestContext, PropertyOperationFlags flags);
 
         static DWORD GetOffsetOfTarget() { return offsetof(JavascriptProxy, target); }
 

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -193,6 +193,24 @@ var tests = [
             assert.throws(() => { "use strict"; let p1 = new Proxy({}, { deleteProperty() { } }); delete p1.foo; }, TypeError, "returning undefined on deleteProperty handler is return false which will throw type error", "Proxy deleteProperty handler returned false");
             assert.throws(() => { "use strict"; let p1 = new Proxy({}, { set() { return false; } }); p1.foo = 1; }, TypeError, "set handler is returning false which will throw type error", "Proxy set handler returned false");
             assert.throws(() => { "use strict"; let p1 = new Proxy({}, { deleteProperty() { return false; } }); delete p1.foo; }, TypeError, "deleteProperty handler is returning false which will throw type error", "Proxy deleteProperty handler returned false");
+
+            const proxy = new Proxy({}, {
+                defineProperty() {
+                    return false;
+                }
+            });
+            assert.doesNotThrow(() => {
+                proxy.a = {};
+            }, "Set property in NON-strict mode does NOT throw if trap returns falsy");
+            assert.throws(() => {
+                "use strict";
+                proxy.b = {};
+            }, TypeError, "Set property in strict mode does DOES throw if trap returns falsy");
+            assert.throws(() => {
+                Object.defineProperty(proxy, "c", {
+                    value: {}
+                });
+            }, TypeError, "Calling 'Object.defineProperty' throws if trap returns falsy");
         }
     },
     {

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -189,10 +189,10 @@ var tests = [
     {
         name: "Strict Mode : throw type error when the handler returns falsy value",
         body: function () {
-            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { set() { } }); p1.foo = 1; }, TypeError, "returning undefined on set handler is return false which will throw type error", "Proxy set handler returned false");
-            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { deleteProperty() { } }); delete p1.foo; }, TypeError, "returning undefined on deleteProperty handler is return false which will throw type error", "Proxy deleteProperty handler returned false");
-            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { set() { return false; } }); p1.foo = 1; }, TypeError, "set handler is returning false which will throw type error", "Proxy set handler returned false");
-            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { deleteProperty() { return false; } }); delete p1.foo; }, TypeError, "deleteProperty handler is returning false which will throw type error", "Proxy deleteProperty handler returned false");
+            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { set() { } }); p1.foo = 1; }, TypeError, "returning undefined on set handler is return false which will throw type error", "Proxy 'set' handler returned falsish for property 'foo'");
+            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { deleteProperty() { } }); delete p1.foo; }, TypeError, "returning undefined on deleteProperty handler is return false which will throw type error", "Proxy 'deleteProperty' handler returned falsish for property 'foo'");
+            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { set() { return false; } }); p1.foo = 1; }, TypeError, "set handler is returning false which will throw type error", "Proxy 'set' handler returned falsish for property 'foo'");
+            assert.throws(() => { "use strict"; let p1 = new Proxy({}, { deleteProperty() { return false; } }); delete p1.foo; }, TypeError, "deleteProperty handler is returning false which will throw type error", "Proxy 'deleteProperty' handler returned falsish for property 'foo'");
 
             const proxy = new Proxy({}, {
                 defineProperty() {

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -307,6 +307,7 @@
     <default>
       <files>misc_bugs.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
+      <tags>exclude_windows</tags>
     </default>
   </test>
   <test>
@@ -471,18 +472,18 @@
       <files>symcmpbug.js</files>
     </default>
   </test>
-  <test>
-    <default>
-      <files>bug_OS17417473.js</files>
-      <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags>
-    </default>
+  <test> 
+    <default> 
+      <files>bug_OS17417473.js</files> 
+      <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags> 
+    </default> 
   </test>
-  <test>
-    <default>
-      <files>HomeObjInLoop.js</files>
-      <compile-flags>-forceNative -forcejitloopbody -off:aggressiveinttypespec -off:ArrayCheckHoist</compile-flags>
-    </default>
-  </test>
+  <test> 
+    <default> 
+      <files>HomeObjInLoop.js</files> 
+      <compile-flags>-forceNative -forcejitloopbody -off:aggressiveinttypespec -off:ArrayCheckHoist</compile-flags> 
+    </default> 
+  </test> 
   <test>
     <default>
       <files>bug17785360.js</files>
@@ -509,7 +510,7 @@
     <default>
       <files>bug_OS17614914.js</files>
     </default>
-  </test>
+  </test> 
   <test>
     <default>
       <files>OS_17745531.js</files>

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -307,7 +307,6 @@
     <default>
       <files>misc_bugs.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
-      <tags>exclude_windows</tags>
     </default>
   </test>
   <test>
@@ -472,18 +471,18 @@
       <files>symcmpbug.js</files>
     </default>
   </test>
-  <test> 
-    <default> 
-      <files>bug_OS17417473.js</files> 
-      <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags> 
-    </default> 
+  <test>
+    <default>
+      <files>bug_OS17417473.js</files>
+      <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags>
+    </default>
   </test>
-  <test> 
-    <default> 
-      <files>HomeObjInLoop.js</files> 
-      <compile-flags>-forceNative -forcejitloopbody -off:aggressiveinttypespec -off:ArrayCheckHoist</compile-flags> 
-    </default> 
-  </test> 
+  <test>
+    <default>
+      <files>HomeObjInLoop.js</files>
+      <compile-flags>-forceNative -forcejitloopbody -off:aggressiveinttypespec -off:ArrayCheckHoist</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>bug17785360.js</files>
@@ -510,7 +509,7 @@
     <default>
       <files>bug_OS17614914.js</files>
     </default>
-  </test> 
+  </test>
   <test>
     <default>
       <files>OS_17745531.js</files>


### PR DESCRIPTION
### Issue
According to [es spec](https://tc39.es/ecma262/#sec-definepropertyorthrow) `Object.defineProperty` should throw if internal `[[DefineOwnProperty]]` returns false-ish.
This happens specifically if the `defineProperty` proxy trap returns false (See #6505).

### Changes
- Throw `TypeError` in `JavascriptObject::EntryDefineProperty` if `DefineOwnPropertyHelper` returns false-ish
- Changed content of `JSERR_ProxyHandlerReturnedFalse`
- Routed `PropertyOperationFlags` through the call stack

### Open questions
- Why is `test\Bugs\misc_bugs.js` tagged with `exclude_windows`?

---

@rhuanjl 

Related to PR #5412
Fixes #6505