### PR TITLE
Fix futex_fatal_error -- issue #6931

### DIFF
--- a/pal/inc/cclock.hpp
+++ b/pal/inc/cclock.hpp
@@ -9,14 +9,9 @@
 #ifndef CC_PAL_INC_CCLOCK_H
 #define CC_PAL_INC_CCLOCK_H
 
-#if defined(_M_ARM64)
-#define CCLOCK_ALIGN __declspec(align(8))
-#else
-#define CCLOCK_ALIGN
-#endif
-
-class CCLOCK_ALIGN CCLock
+class CCLock
 {
+    __declspec(align(sizeof(size_t)))
     char           mutexPtr[64]; // keep mutex implementation opaque to consumer (PAL vs non-PAL)
 
 public:


### PR DESCRIPTION
In cclock.hpp we reserve storage for a mutex, but didn't specify alignment for it (except on ARM64).

That resulted in an unaligned pthread_mutex_t on Linux, when built with Clang 14.0.6 on x86_64 Ubuntu.