### PR TITLE
Remove a Ubuntu 18.04 jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,16 +47,6 @@ jobs:
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'Release'
           libtype_flag: ''
-        Ubuntu18.ReleaseWithDebug:
-          image_name: 'ubuntu-18.04'
-          deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
-          build_type: 'RelWithDebInfo'
-          libtype_flag: ''
-        Ubuntu18.Release:
-          image_name: 'ubuntu-18.04'
-          deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
-          build_type: 'Release'
-          libtype_flag: ''
         OSX.DebugNoICU:
           image_name: 'macOS-latest'
           deps: 'brew install ninja'


### PR DESCRIPTION
To fix a CI/CD errors, need to remove a Ubuntu 18.04 jobs.