### PR TITLE
Avoid using MSVC-internal `_STRINGIZE`

### DIFF
--- a/bin/NativeTests/stdafx.h
+++ b/bin/NativeTests/stdafx.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
@@ -25,11 +26,16 @@
 
 #define DebugOnly(x)          x
 
+#if !defined(CHAKRACORE_STRINGIZE)
+#define CHAKRACORE_STRINGIZE_IMPL(x) #x
+#define CHAKRACORE_STRINGIZE(x) CHAKRACORE_STRINGIZE_IMPL(x)
+#endif
+
 #define AssertMsg(exp, comment)   \
 do { \
 if (!(exp)) \
 { \
-    fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, _STRINGIZE(exp), comment); \
+    fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, CHAKRACORE_STRINGIZE(exp), comment); \
     fflush(stderr); \
     DebugBreak(); \
 } \

--- a/bin/ch/stdafx.h
+++ b/bin/ch/stdafx.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
@@ -57,16 +57,16 @@
 
 #if defined(DBG)
 
-#define _STRINGIZE_(x) #x
-#if !defined(_STRINGIZE)
-#define _STRINGIZE(x) _STRINGIZE_(x)
+#if !defined(CHAKRACORE_STRINGIZE)
+#define CHAKRACORE_STRINGIZE_IMPL(x) #x
+#define CHAKRACORE_STRINGIZE(x) CHAKRACORE_STRINGIZE_IMPL(x)
 #endif
 
 #define AssertMsg(exp, comment)   \
 do { \
 if (!(exp)) \
 { \
-    fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, _STRINGIZE(exp), comment); \
+    fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, CHAKRACORE_STRINGIZE(exp), comment); \
     fflush(stderr); \
     DebugBreak(); \
 } \

--- a/pal/inc/assert_only.h
+++ b/pal/inc/assert_only.h
@@ -1,25 +1,30 @@
 //-------------------------------------------------------------------------------------------------------
-// Copyright (C) Microsoft. All rights reserved.
+// ChakraCore/Pal
+// Contains portions (c) copyright Microsoft, portions copyright (c) the .NET Foundation and Contributors
+// and edits (c) copyright the ChakraCore Contributors.
+// See THIRD-PARTY-NOTICES.txt in the project root for .NET Foundation license
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
 // PAL free Assert definitions
 #ifdef DEBUG
 
-#define _QUOTE_(s) #s
-#define _STRINGIZE_(s) _QUOTE_(s)
+#if !defined(CHAKRACORE_STRINGIZE)
+#define CHAKRACORE_STRINGIZE_IMPL(x) #x
+#define CHAKRACORE_STRINGIZE(x) CHAKRACORE_STRINGIZE_IMPL(x)
+#endif
 
 #ifndef __ANDROID__
 #define _ERR_OUTPUT_(condition, comment) \
     fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, \
-      _STRINGIZE_(condition), comment); \
+      CHAKRACORE_STRINGIZE(condition), comment); \
     fflush(stderr);
 #else // ANDROID
 #include <android/log.h>
 #define _ERR_OUTPUT_(condition, comment) \
     __android_log_print(ANDROID_LOG_ERROR, "chakracore-log", \
       "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, \
-      _STRINGIZE_(condition), comment);
+      CHAKRACORE_STRINGIZE(condition), comment);
 #endif
 
 #define _Assert_(condition, comment)   \


### PR DESCRIPTION
I work on Microsoft's C++ Standard Library implementation, where we recently merged microsoft/STL#4405 to remove our internal `_STRINGIZE` macro. Our "Real World Code" test suite, which builds popular open-source projects like yours, found that you were using this MSVC-internal macro and therefore our change broke your code.

The C++ Standard's rule is that `_Leading_underscore_capital` identifiers (including `_LEADING_UNDERSCORE_ALL_CAPS`) are reserved for the compiler and Standard Library, so other libraries and applications should avoid using such reserved identifiers. This is [N4971](https://isocpp.org/files/papers/N4971.pdf) 5.10 \[lex.name\]/3:

> In addition, some identifiers appearing as a *token* or *preprocessing-token* are reserved for use by C++ implementations and shall not be used otherwise; no diagnostic is required.
> — Each identifier that contains a double underscore `__` or begins with an underscore followed by an uppercase letter is reserved to the implementation for any use.

This PR introduces non-reserved names that will work on all platforms.