### PR TITLE
Prevent defining `_GUARD_CHECK_ICALL` twice

### DIFF
--- a/lib/Runtime/Base/ThreadContextInfo.cpp
+++ b/lib/Runtime/Base/ThreadContextInfo.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 

--- a/lib/Runtime/Base/ThreadContextInfo.cpp
+++ b/lib/Runtime/Base/ThreadContextInfo.cpp
@@ -21,6 +21,10 @@
 # else
    extern "C" void __fastcall _guard_check_icall(_In_ uintptr_t _Target);
 # endif
+
+# ifndef _GUARD_CHECK_ICALL
+#  define _GUARD_CHECK_ICALL _guard_check_icall
+# endif
 #endif
 
 ThreadContextInfo::ThreadContextInfo() :

--- a/lib/Runtime/Base/ThreadContextInfo.h
+++ b/lib/Runtime/Base/ThreadContextInfo.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 

--- a/lib/Runtime/Base/ThreadContextInfo.h
+++ b/lib/Runtime/Base/ThreadContextInfo.h
@@ -178,7 +178,3 @@ uintptr_t ShiftAddr(const ThreadContextInfo*const context, T* address)
 }
 
 uintptr_t ShiftAddr(const ThreadContextInfo*const context, uintptr_t address);
-
-#ifndef _GUARD_CHECK_ICALL
-#define _GUARD_CHECK_ICALL _guard_check_icall
-#endif


### PR DESCRIPTION
CI fails because MVC defines `_GUARD_CHECK_ICALL` after CC defines it

---

Added in: 9b6c91d3c0447801a020d7c544adb1f0ca574566
@rhuanjl 