### PR TITLE
Upload `bin` directory to azure artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,6 +107,7 @@ jobs:
           special_build: ''
           do_test: true
           test_tags: ''
+          build_outdir_suffix: ''
         x86.Test:
           image_name: 'windows-2022'
           build_type: 'test'
@@ -114,6 +115,7 @@ jobs:
           special_build: ''
           do_test: true
           test_tags: '--include-slow'
+          build_outdir_suffix: ''
         x86.NoJit:
           image_name: 'windows-2022'
           build_type: 'debug'
@@ -121,6 +123,7 @@ jobs:
           special_build: '"/p:BuildJIT=false"'
           do_test: true
           test_tags: '-disablejit'
+          build_outdir_suffix: '.NoJIT'
         x86.Release:
           image_name: 'windows-2022'
           build_type: 'release'
@@ -128,6 +131,7 @@ jobs:
           special_build: ''
           do_test: false
           test_tags: ''
+          build_outdir_suffix: ''
         x64.Debug:
           image_name: 'windows-2022'
           build_type: 'debug'
@@ -135,6 +139,7 @@ jobs:
           special_build: ''
           do_test: true
           test_tags: ''
+          build_outdir_suffix: ''
         x64.Test:
           image_name: 'windows-2022'
           build_type: 'test'
@@ -142,6 +147,7 @@ jobs:
           special_build: ''
           do_test: true
           test_tags: '--include-slow'
+          build_outdir_suffix: ''
         x64.Release:
           image_name: 'windows-2022'
           build_type: 'release'
@@ -149,6 +155,7 @@ jobs:
           special_build: ''
           do_test: false
           test_tags: ''
+          build_outdir_suffix: ''
         win19.x86.Release:
           image_name: 'windows-2019'
           build_type: 'release'
@@ -156,6 +163,7 @@ jobs:
           special_build: ''
           do_test: false
           test_tags: ''
+          build_outdir_suffix: ''
         win19.x64.Release:
           image_name: 'windows-2019'
           build_type: 'release'
@@ -163,6 +171,7 @@ jobs:
           special_build: ''
           do_test: false
           test_tags: ''
+          build_outdir_suffix: ''
     pool:
       vmImage: $(image_name)
       
@@ -174,7 +183,7 @@ jobs:
         BUILD: $(build_type)
         SPECIAL: $(special_build)
 
-    - publish: $(System.DefaultWorkingDirectory)/Build/VcBuild/bin
+    - publish: $(System.DefaultWorkingDirectory)/Build/VcBuild$(matrix.build_outdir_suffix)/bin
       artifact: $(Agent.JobName)
 
     - script: test\ci.testone.cmd %TARGET% %BUILD% %TEST_TAGS%

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,13 +87,12 @@ jobs:
         ninja
       displayName: 'Build'
 
+    - publish: $(System.DefaultWorkingDirectory)/build/bin
+
     - script: |
         cd build
         ninja check
       displayName: 'Test'
-
-    - publish: $(System.DefaultWorkingDirectory)/build/bin
-      artifact: CMake-Bin
 
   - job: MSVC
     timeoutInMinutes: 120
@@ -174,6 +173,8 @@ jobs:
         BUILD: $(build_type)
         SPECIAL: $(special_build)
 
+    - publish: $(System.DefaultWorkingDirectory)/Build/VcBuild/bin
+
     - script: test\ci.testone.cmd %TARGET% %BUILD% %TEST_TAGS%
       displayName: 'Test'
       condition: eq(variables['do_test'], true)
@@ -181,6 +182,3 @@ jobs:
         TARGET: $(target)
         BUILD: $(build_type)
         TEST_TAGS: ${test_tags}
-    
-    - publish: $(System.DefaultWorkingDirectory)/Build/VcBuild/bin
-      artifact: MSVC-Bin

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,7 +183,7 @@ jobs:
         BUILD: $(build_type)
         SPECIAL: $(special_build)
 
-    - publish: $(System.DefaultWorkingDirectory)/Build/VcBuild$(matrix.build_outdir_suffix)/bin
+    - publish: $(System.DefaultWorkingDirectory)/Build/VcBuild$(build_outdir_suffix)/bin
       artifact: $(Agent.JobName)
 
     - script: test\ci.testone.cmd %TARGET% %BUILD% %TEST_TAGS%

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,7 @@ jobs:
       displayName: 'Build'
 
     - publish: $(System.DefaultWorkingDirectory)/build/bin
+      artifact: $(Agent.JobName)
 
     - script: |
         cd build
@@ -174,6 +175,7 @@ jobs:
         SPECIAL: $(special_build)
 
     - publish: $(System.DefaultWorkingDirectory)/Build/VcBuild/bin
+      artifact: $(Agent.JobName)
 
     - script: test\ci.testone.cmd %TARGET% %BUILD% %TEST_TAGS%
       displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------------------------------
-# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Copyright (c) ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
@@ -92,6 +92,9 @@ jobs:
         ninja check
       displayName: 'Test'
 
+    - publish: $(System.DefaultWorkingDirectory)/build/bin
+      artifact: CMake-Bin
+
   - job: MSVC
     timeoutInMinutes: 120
     strategy:
@@ -178,3 +181,6 @@ jobs:
         TARGET: $(target)
         BUILD: $(build_type)
         TEST_TAGS: ${test_tags}
+    
+    - publish: $(System.DefaultWorkingDirectory)/Build/VcBuild/bin
+      artifact: MSVC-Bin


### PR DESCRIPTION
## Goals
- Provide "nightly" builds for all platforms
- Allow to debug per PR issues using the binaries from a CI-Run

## Issues
- macOS-builds created on CirrusCI are not included

---

Docs: [Azure Pipeline Artifacts](https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-artifacts)