### PR TITLE
Enable Ubuntu 22 CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------------------------------
-# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Copyright (c) ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
@@ -32,17 +32,32 @@ jobs:
     strategy:
       maxParallel: 6
       matrix:
+        Linux.Debug:
+          image_name: 'ubuntu-22.04'
+          deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
+          build_type: 'Debug'
+          libtype_flag: ''
         Linux.NoJit:
-          image_name: 'ubuntu-20.04'
+          image_name: 'ubuntu-22.04'
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'Debug'
           libtype_flag: '-DDISABLE_JIT=ON'
         Linux.ReleaseWithDebug:
-          image_name: 'ubuntu-20.04'
+          image_name: 'ubuntu-22.04'
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'RelWithDebInfo'
           libtype_flag: ''
         Linux.Release:
+          image_name: 'ubuntu-22.04'
+          deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
+          build_type: 'Release'
+          libtype_flag: ''
+        Ubuntu20.ReleaseWithDebug:
+          image_name: 'ubuntu-20.04'
+          deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
+          build_type: 'RelWithDebInfo'
+          libtype_flag: ''
+        Ubuntu20.Release:
           image_name: 'ubuntu-20.04'
           deps: 'sudo apt-get install -y ninja-build clang libicu-dev'
           build_type: 'Release'

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
-# Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+# Copyright (c) ChakraCore Project Contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
@@ -316,11 +316,11 @@ class TestVariant(object):
 
     @staticmethod
     def _has_expansion(flags):
-        return any(re.match('.*\${.*}', f) for f in flags)
+        return any(re.match(r'.*\${.*}', f) for f in flags)
 
     @staticmethod
     def _expand(flag, test):
-        return re.sub('\${id}', str(test.id), flag)
+        return re.sub(r'\${id}', str(test.id), flag)
 
     def _expand_compile_flags(self, test):
         if self._compile_flags_has_expansion:


### PR DESCRIPTION
Update CI for Ubuntu 22. Also fix a python syntax error that was being printed in our macOS and Ubuntu CI logs