### PR TITLE
Module api bugs

### DIFF
--- a/lib/Jsrt/Core/JsrtContextCore.h
+++ b/lib/Jsrt/Core/JsrtContextCore.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
@@ -266,8 +267,6 @@ public:
 #endif
 
 private:
-    template<typename Fn>
-    HRESULT FetchImportedModuleHelper(Fn fetch, LPCOLESTR specifier, Js::ModuleRecordBase** dependentModuleRecord);
     FetchImportedModuleCallBack fetchImportedModuleCallback;
     FetchImportedModuleFromScriptCallBack fetchImportedModuleFromScriptCallback;
     NotifyModuleReadyCallback notifyModuleReadyCallback;

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "JsrtPch.h"
@@ -267,6 +267,10 @@ CHAKRA_API JsGetModuleNamespace(_In_ JsModuleRecord requestModule, _Outptr_resul
     if (!moduleRecord->WasEvaluated())
     {
         return JsErrorModuleNotEvaluated;
+    }
+    if (moduleRecord->GetErrorObject() != nullptr)
+    {
+        return JsErrorInvalidArgument;
     }
     *moduleNamespace = static_cast<JsValueRef>(moduleRecord->GetNamespace());
     return JsNoError;


### PR DESCRIPTION
These two small bugs have been knocking around for a while; both relate to incorrect/unintended use of the hosting APIs but they both can lead to nullptr de-refs rather than returning error codes as an embedder should expect.

1. When a module was imported from a script triggerring the fetchImportedModuleFromScriptCallback, CC was incorrectly checking if the fetchImportedModuledCallback was set but not checking the callback it was actually going to use. (I did a minor refactor fixing this, eliminating a helper method as whilst this meant some small code duplication it was a net 0 change to total lines of code, gained lines are fix number 2 and copyright changes)
2. When GetModuleNumespace was invked on a module marked as evaluated BUT having a syntax error, CC was performing a nullptr de-ref rather than returning an error code.

FYI @fatcerberus 

Fix: #5880 
Fix: #6788 