### PR TITLE
Fix JsDisableRuntimeExecution on AppleSilicon

### DIFF
--- a/lib/Runtime/Base/Constants.cpp
+++ b/lib/Runtime/Base/Constants.cpp
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeBasePch.h"
@@ -29,7 +30,7 @@ const char16 Constants::StringMatch[] = _u("String.prototype.match");
 const uint64 Constants::ExponentMask = 0x3FF0000000000000;
 const uint64 Constants::MantissaMask = 0x000FFFFFFFFFFFFF;
 
-#ifdef _M_AMD64
+#ifdef TARGET_64
 const size_t Constants::StackLimitForScriptInterrupt = 0x7fffffffffffffff;
 #else
 const size_t Constants::StackLimitForScriptInterrupt = 0x7fffffff;


### PR DESCRIPTION
JsDisableRuntimeExecution currently does not function on AppleSilicon.

This is because of an incorrect ifdef, JsDisableRuntimeExecution works by overriding CC's stack size tracking so that CC mistakenly thinks there is no stack space left and hence stops executing JS; in order to do this `StackLimitForScriptInterrupt` needs to be an appropriately large number for the architecture, currently it's being set to the same size on AppleSilicon that was used for x86 which is obviously not high enough, change the ifdef so all 64bit architectures (i.e. x64 and AppleSilicon) get the larger figure.

Bug reported by @fatcerberus fix also tested offline by @fatcerberus 

Currently most of our native API tests only run on windows hence do not detect this; we should look at enabling them on macOS/Linux as a future todo.