### PR TITLE
Fix MacOS build

### DIFF
--- a/lib/Common/Memory/Allocator.h
+++ b/lib/Common/Memory/Allocator.h
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
@@ -448,6 +449,8 @@ void AssertValue(void * mem, T value, uint byteCount)
 #define NO_EXPORT(x) x
 #endif
 
+#if defined(_MSC_VER) && !defined(__clang__)
+
 // For the debugger extension, we don't need the placement news
 #ifndef __PLACEMENT_NEW_INLINE
 #define __PLACEMENT_NEW_INLINE
@@ -470,6 +473,14 @@ void * previousAllocation               // Previously allocated memory
 {
 
 }
+
+#endif
+
+#else
+
+// Use std inline placement new instead of custom
+// See PR #7009
+#include <new>
 
 #endif
 


### PR DESCRIPTION
### TL;DR
MacOs builds using latest `icu4c` fail because the "placement new operator" is defined in the standard-library and in `Allocator.h`.

## Issue
As far as I understand the issue (might be wrong)
- CC source defines a `new` operator that used an already existing allocation (`previousAllocation`)
https://github.com/chakra-core/ChakraCore/blob/e26c81f6eabf3b4c0f45c3963be807d3ea90c63e/lib/Common/Memory/Allocator.h#L451-L474
- This code was added in the [Initial commit](https://github.com/chakra-core/ChakraCore/blob/5d8406741f8c60e7bf0a06e4fb71a5cf7a6458dc/lib/common/Memory/Allocator.h#L334-L357)
- This might exist to speed-up builds because the compiler does not have to parse the full `new` header for every compilation unit that uses the custom CC `Allocator.h`.
- It might also have forced compilers to inline this no-op call (Seems like they do now)
- See https://github.com/llvm/llvm-project/pull/70538

## Std lib

<details>
<summary>MSVC</summary>

The `__PLACEMENT_NEW_INLINE` flag can be used to disable placement new declaration in MSVC (v14.43.34808)
See `vcruntime_new.h` (imported by `new`):
```c++
#ifndef __PLACEMENT_NEW_INLINE
    #define __PLACEMENT_NEW_INLINE
    _VCRT_EXPORT_STD _NODISCARD _MSVC_CONSTEXPR _Ret_notnull_ _Post_writable_byte_size_(_Size) _Post_satisfies_(return == _Where)
    inline void* __CRTDECL operator new(size_t _Size,
        _Writable_bytes_(_Size) void* _Where) noexcept
    {
        (void)_Size;
        return _Where;
    }

    _VCRT_EXPORT_STD inline void __CRTDECL operator delete(void*, void*) noexcept
    {
        return;
    }
#endif
```

</details>
<details>
<summary>MacOs</summary>
This is from the MacOSX14.5 sdk (There seems no way to disable it llvm/llvm-project/pull/70538)

```c++
_LIBCPP_NODISCARD_AFTER_CXX17 inline _LIBCPP_INLINE_VISIBILITY void* operator new  (std::size_t, void* __p) _NOEXCEPT {return __p;}
_LIBCPP_NODISCARD_AFTER_CXX17 inline _LIBCPP_INLINE_VISIBILITY void* operator new[](std::size_t, void* __p) _NOEXCEPT {return __p;}
inline _LIBCPP_INLINE_VISIBILITY void  operator delete  (void*, void*) _NOEXCEPT {}
inline _LIBCPP_INLINE_VISIBILITY void  operator delete[](void*, void*) _NOEXCEPT {}
```

</details>

## Why did it work before?
- The definition of `__PLACEMENT_NEW_INLINE` solved the problem for MSVC
- The problem did not happen on other platforms / using other compilers because there was likely no compilation unit that used libcxx `new` and CC `Allocator.h` at the same time.
- Different compilation units don't collide because their definitions are made "private" using the CC custom `NO_EXPORT` macro
https://github.com/chakra-core/ChakraCore/blob/e26c81f6eabf3b4c0f45c3963be807d3ea90c63e/lib/Common/Memory/Allocator.h#L443-L449

## What's different now?
- libicu on MacOS does now include `new` into a compilation unit that also uses `Allocator.h`
- This leads to 2 different declarations of the same operator inside the same compilation unit
⇒ Error

<details>
<summary>StackTrace</summary>

```
In file included from /Users/test/Documents/Projects/ChakraCore/lib/Backend/Encoder.cpp:5:
In file included from /Users/test/Documents/Projects/ChakraCore/lib/Backend/Backend.h:12:
In file included from /Users/test/Documents/Projects/ChakraCore/lib/Backend/../Runtime/Runtime.h:334:
In file included from /Users/test/Documents/Projects/ChakraCore/lib/Backend/../Runtime/PlatformAgnostic/ChakraPlatform.h:7:
In file included from /Users/test/Documents/Projects/ChakraCore/lib/Backend/../Runtime/PlatformAgnostic/UnicodeText.h:8:
In file included from /Users/test/Documents/Projects/ChakraCore/lib/Backend/../Runtime/PlatformAgnostic/ChakraICU.h:38:
In file included from /usr/local/opt/icu4c/include/unicode/ucol.h:1524:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/functional:521:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__functional/bind.h:20:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/tuple:1868:
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/new:277:70: error: redefinition of 'operator new'
_LIBCPP_NODISCARD_AFTER_CXX17 inline _LIBCPP_INLINE_VISIBILITY void* operator new  (std::size_t, void* __p) _NOEXCEPT {return __p;}
                                                                     ^
/Users/test/Documents/Projects/ChakraCore/lib/Common/Memory/Allocator.h:457:1: note: previous definition is here
operator new(
^
```

</details>

## Potential Solution
As this specific `new` overload is part of the standard-library it might be okay to just remove the custom declaration in CC and always `#include <new>` instead.

## Risks
As the implementation is identical there should be no immediate risks, but...
- We might face slower build-times due to more required parsing

I don't think these 2 are true but we need prove for that
- The compiler might not inline this no-op function call
⇒ Additional function call might reduce runtime performance
- Including `new` could have side-effects

---

Fixes #7007