### PR TITLE
Fix JsPointerToString to handle NULL pointer with length 0

### DIFF
--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -1234,6 +1234,20 @@ CHAKRA_API JsPointerToString(_In_reads_(stringLength) const WCHAR *stringValue, 
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
         PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTCreateString, stringValue, stringLength);
 
+        // Special case: allow NULL pointer only if length is 0 → return empty string
+        if (stringValue == nullptr && stringLength == 0)
+        {
+            if (string == nullptr)
+            {
+                return JsErrorInvalidArgument; // output pointer cannot be NULL
+            }
+
+            *string = Js::JavascriptString::NewCopyBuffer(_u(""), 0, scriptContext);
+            PERFORM_JSRT_TTD_RECORD_ACTION_RESULT(scriptContext, string);
+            return JsNoError;
+        }
+
+        // Original null checks for all other cases
         PARAM_NOT_NULL(stringValue);
         PARAM_NOT_NULL(string);
 
@@ -1249,6 +1263,7 @@ CHAKRA_API JsPointerToString(_In_reads_(stringLength) const WCHAR *stringValue, 
         return JsNoError;
     });
 }
+
 
 // TODO: The annotation of stringPtr is wrong.  Need to fix definition in chakrart.h
 // The warning is '*stringPtr' could be '0' : this does not adhere to the specification for the function 'JsStringToPointer'.


### PR DESCRIPTION
### Summary
This PR fixes the `JsPointerToString` API to handle the case where the input pointer is `NULL` and the string length is 0. Previously, this would return `JsErrorNullArgument`, but the expected behavior is to return an empty string.

### Changes
- Added a special-case check for `(stringValue == nullptr && stringLength == 0)` to return an empty string.
- Preserved all existing null checks and validation for other cases.
- TTD recording (`PERFORM_JSRT_TTD_RECORD_ACTION_RESULT`) is maintained for this branch.

### Motivation
- Matches expected behavior described in comments in ChakraCore.
- Improves usability of the API for cases where an empty string is needed.

### Testing
- Local test not run (will request review for validation by maintainers).
