### PR TITLE
fix: linux build

### DIFF
--- a/pal/src/cruntime/finite.cpp
+++ b/pal/src/cruntime/finite.cpp
@@ -1,7 +1,10 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
-//
+//-------------------------------------------------------------------------------------------------------
+// ChakraCore/Pal
+// Contains portions (c) copyright Microsoft, portions copyright (c) the .NET Foundation and Contributors
+// and edits (c) copyright the ChakraCore Contributors.
+// See THIRD-PARTY-NOTICES.txt in the project root for .NET Foundation license
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
 
 /*++
 

--- a/pal/src/cruntime/finite.cpp
+++ b/pal/src/cruntime/finite.cpp
@@ -19,9 +19,9 @@ Abstract:
 
 --*/
 
+#include <math.h>
 #include "pal/palinternal.h"
 #include "pal/dbgmsg.h"
-#include <math.h>
 
 #if HAVE_IEEEFP_H
 #include <ieeefp.h>


### PR DESCRIPTION
`palinternal.h` defines a fallback for the `min` and `max` macros in case the compiler does not:
https://github.com/chakra-core/ChakraCore/blob/36becec43348f259e8bee08cf2fcd171bfe56f42/pal/src/include/pal/palinternal.h#L689-L696

`finite.cpp` imports `palinternal.h` before `<math>` so we end up with two conflicting definitions of `min` and `max`:
https://github.com/chakra-core/ChakraCore/blob/36becec43348f259e8bee08cf2fcd171bfe56f42/pal/src/cruntime/finite.cpp#L22-L24

---

@rhuanjl This is the first in a stack of PRs that will hopefully fix MacOS ci.
Until then, MacOS builds will fail...