### PR TITLE
fix: MacOS build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode
   Dependencies_script:  brew install ninja icu4c && mkdir -p build
-  CMake_script: cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DSTATIC_LIBRARY=ON -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include -DDISABLE_JIT=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
+  CMake_script: cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DSTATIC_LIBRARY=ON -DEMBED_ICU=ON -DDISABLE_JIT=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
   Build_script: cd build && ninja
   Test_script: cd build && ninja check
 
@@ -17,7 +17,7 @@ task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode
   Dependencies_script:  brew install ninja icu4c && mkdir -p build
-  CMake_script: cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include -DDISABLE_JIT=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
+  CMake_script: cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DEMBED_ICU=ON -DDISABLE_JIT=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
   Build_script: cd build && ninja
   Test_script: cd build && ninja check
 
@@ -26,6 +26,6 @@ task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode
   Dependencies_script:  brew install ninja icu4c && mkdir -p build
-  CMake_script: cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC_LIBRARY=ON -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include -DDISABLE_JIT=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
+  CMake_script: cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC_LIBRARY=ON -DEMBED_ICU=ON -DDISABLE_JIT=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
   Build_script: cd build && ninja
   Test_script: cd build && ninja check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project (CHAKRACORE)
 
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,9 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
     # prevent the required interface is being exported
     # clang by default sets fvisibility=default
 
+    # Allow ch to export `OnChakraCoreLoadedEntry`
+    set(CMAKE_ENABLE_EXPORTS ON)
+
     # CXX WARNING FLAGS
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
         -Wno-ignored-attributes\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,12 +71,12 @@ jobs:
           image_name: 'macOS-latest'
           deps: 'brew install ninja icu4c'
           build_type: 'RelWithDebInfo'
-          libtype_flag: '-DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include'
+          libtype_flag: '-DEMBED_ICU=ON'
         OSX.Release:
           image_name: 'macOS-latest'
           deps: 'brew install ninja icu4c'
           build_type: 'Release'
-          libtype_flag: '-DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include'
+          libtype_flag: '-DEMBED_ICU=ON'
 
     pool:
       vmImage: $(image_name)

--- a/lib/Runtime/Language/amd64/amd64_Thunks.S
+++ b/lib/Runtime/Language/amd64/amd64_Thunks.S
@@ -64,10 +64,10 @@ NESTED_ENTRY _ZN2Js21InterpreterStackFrame33AsmJsDelayDynamicInterpreterThunkEPN
 
         call C_FUNC(_ZN2Js11WasmLibrary20EnsureWasmEntrypointEPNS_14ScriptFunctionE)
         test rax, rax
-        jne skipThunk
+        jne LOCAL_LABEL(skipThunk)
         mov rdi, [rbp-0x8]
         call C_FUNC(_ZN2Js21InterpreterStackFrame29EnsureDynamicInterpreterThunkEPNS_14ScriptFunctionE)
-skipThunk:
+LOCAL_LABEL(skipThunk):
 
         pop r9
         pop r8
@@ -267,7 +267,7 @@ NESTED_ENTRY _ZN2Js23AsmJsExternalEntryPointEPNS_16RecyclableObjectENS_8CallInfo
         call C_FUNC(_ZN2Js19BoxAsmJsReturnValueEPNS_14ScriptFunctionEldfDv4_f)
 
         mov rsp, r13 // restore stack pointer
-    Epilogue:
+LOCAL_LABEL(Epilogue):
         mov r12, [rsp + 0x28]
         .cfi_restore r12
         mov r13, [rsp + 0x30]

--- a/lib/Runtime/Language/amd64/amd64_Thunks.S
+++ b/lib/Runtime/Language/amd64/amd64_Thunks.S
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 .intel_syntax noprefix

--- a/lib/wabt/CMakeLists.txt
+++ b/lib/wabt/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 project(WABT)
 
 set(COMPILER_IS_CLANG 1)

--- a/lib/wabt/README.md
+++ b/lib/wabt/README.md
@@ -44,7 +44,7 @@ This will fetch the testsuite and gtest repos, which are needed for some tests.
 You'll need [CMake](https://cmake.org). If you just run `make`, it will run
 CMake for you, and put the result in `out/clang/Debug/` by default:
 
-> Note: If you are on macOS, you will need to use CMake version 3.2 or higher
+> Note: If you are on macOS, you will need to use CMake version 3.10 or higher
 
 ```console
 $ make

--- a/pal/CMakeLists.txt
+++ b/pal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(COREPAL)
 

--- a/pal/src/CMakeLists.txt
+++ b/pal/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(chakrapal)
 

--- a/tools/RecyclerChecker/CMakeLists.txt
+++ b/tools/RecyclerChecker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 # set(CMAKE_VERBOSE_MAKEFILE on)


### PR DESCRIPTION
### Issues
- Modern MacOS only supports CMake >= 3.5
- Modern libICU requires c++17
- clang reports an `invalid CFI advance_loc expression`

### Changes
- Upgrade to CMake 3.10 (Ubuntu 25.04 shows deprecation warning for < 3.10)
- Set `EMBED_ICU` to pin libicu for now
- Ensure labels for local jumps are "private" using our own `LOCAL_LABEL` definition
  https://gitlab.winehq.org/wine/wine/-/merge_requests/4547
  https://github.com/chakra-core/ChakraCore/blob/22f16199897c9623c6efe3fb573725d2189b56d5/pal/inc/unixasmmacros.inc#L8-L16

---

Fixes #7031