### PR TITLE
refactor: c++ 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,7 +372,8 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
         -D__STDC_WANT_LIB_EXT1__=1
         )
 
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED On)
 
     # todo: fix general visibility of the interface
     # do not set to `fvisibility=hidden` as it is going to
@@ -393,7 +394,6 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
         -Wno-invalid-offsetof\
         -Wno-undefined-inline\
         -Wno-inconsistent-missing-override\
-        -Wno-c++14-extensions\
         -Wno-macro-redefined\
         -Wno-pragmas\
         -Wno-invalid-token-paste\

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -1,10 +1,13 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft Corporation and contributors. All rights reserved.
-// Copyright (c) 2021 ChakraCore Project Contributors. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "stdafx.h"
 #include "PlatformAgnostic/ChakraICU.h"
+#ifdef __valid
+#undef __valid
+#endif
 #if defined(__APPLE__)
 #ifdef ctime
 #undef ctime


### PR DESCRIPTION
My install of VisualStudio already uses c++14 to compile CC.
Update CMake project to use c++14 aswell.

### 💥 Breaking changes
- Macro collision between `pal/inc/rt/sal.h` and `/include/c++/12/bits/parse_numbers.h`
  ⇾ `#undef __valid`

---

✅ This PR is stacked onto #7040.