### PR TITLE
ci: scheduled runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,15 @@ trigger:
 - master
 - release/*
 
+schedules:
+- cron: "0 0 * * 1" # At 00:00 on Monday
+  displayName: Weekly Monday Midnight
+  branches:
+    include:
+    - master
+    - release/*
+  always: true
+
 jobs:
   - job: Style
     timeoutInMinutes: 10

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -270,14 +270,14 @@ Below test fails with difference in space. Investigate the cause and re-enable t
   <test>
     <default>
       <files>allocation.js</files>
-      <tags>typedarray,exclude_arm,xplatslow,Slow</tags>
+      <tags>typedarray,exclude_arm,xplatslow,Slow,exclude_x86</tags>
       <timeout>300</timeout>
     </default>
   </test>
   <test>
     <default>
       <files>allocation2.js</files>
-      <tags>typedarray,exclude_arm,xplatslow,Slow</tags>
+      <tags>typedarray,exclude_arm,xplatslow,Slow,exclude_x86</tags>
       <timeout>300</timeout>
     </default>
   </test>


### PR DESCRIPTION
Execute the pipeline every week to catch build-issues early:

- Azure DevOps [scheduled triggers](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&pivots=pipelines-yaml#cron-syntax)
- ⚠️ Cirrus needs [manual configuration](https://cirrus-ci.org/guide/writing-tasks/#cron-builds)

### Prevent false positives
As proposed in https://github.com/chakra-core/ChakraCore/pull/7041#issuecomment-3377965961 this PR excludes the `typedarray/allocation{,2}.js` tests from x86 as the regularity fail with exit code `1073807364`.
https://github.com/chakra-core/ChakraCore/blob/c6a95497dfaf06385cdf2edb8eff826fdceff623/pal/inc/pal.h#L6814

<details>
<summary>[Potential CallStack] This is likely due to out-of-memory.</summary>

https://github.com/chakra-core/ChakraCore/blob/c6a95497dfaf06385cdf2edb8eff826fdceff623/lib/Runtime/Language/JavascriptExceptionOperators.cpp#L1253-L1262
https://github.com/chakra-core/ChakraCore/blob/c6a95497dfaf06385cdf2edb8eff826fdceff623/lib/Common/Exceptions/ReportError.cpp#L143-L147
https://github.com/chakra-core/ChakraCore/blob/c6a95497dfaf06385cdf2edb8eff826fdceff623/lib/Common/Exceptions/ReportError.cpp#L10-L26
https://github.com/chakra-core/ChakraCore/blob/c6a95497dfaf06385cdf2edb8eff826fdceff623/lib/Common/Exceptions/ReportError.cpp#L24-L26

</details>

---

@rhuanjl 