### PR TITLE
chore: support visual studio 2026

### DIFF
--- a/Build/Common.Build.Default.props
+++ b/Build/Common.Build.Default.props
@@ -19,6 +19,7 @@
     <PlatformToolset Condition="'$(BuildToolVersion)'=='15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(BuildToolVersion)'=='16.0'">v142</PlatformToolset>
     <PlatformToolset Condition="'$(BuildToolVersion)'=='17.0'">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(BuildToolVersion)'=='18.0'">v145</PlatformToolset>
   </PropertyGroup>
 
   <!-- Default ChakraDevConfigDir -->


### PR DESCRIPTION
Visual Studio 2026 is now [generally available](https://devblogs.microsoft.com/visualstudio/visual-studio-2026-is-here-faster-smarter-and-a-hit-with-early-adopters/).

It uses [Toolset `v145`](https://devblogs.microsoft.com/cppblog/c-language-updates-in-msvc-build-tools-v14-50/) as Toolset `v144` was already [introduced in VS 2022 v17.10](https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/).