### PR TITLE
ci: use windows 2025 runners

### DIFF
--- a/Build/Chakra.Build.Default.props
+++ b/Build/Chakra.Build.Default.props
@@ -29,7 +29,7 @@
     <EnableIntl Condition="'$(EnableIntl)'==''">true</EnableIntl>
     <EnableIntl Condition="'$(BuildLite)'=='true'">false</EnableIntl>
 
-    <ChakraICU Condition="'$(ChakraICU)'==''">false</ChakraICU>
+    <ChakraICU Condition="'$(ChakraICU)'==''">windows</ChakraICU>
 
     <BuildChakraICUData Condition="'$(BuildChakraICUData)'=='' AND ('$(ChakraICU)'=='static' OR '$(ChakraICU)'=='shared')">true</BuildChakraICUData>
 

--- a/Build/Chakra.Build.Default.props
+++ b/Build/Chakra.Build.Default.props
@@ -33,6 +33,6 @@
 
     <BuildChakraICUData Condition="'$(BuildChakraICUData)'=='' AND ('$(ChakraICU)'=='static' OR '$(ChakraICU)'=='shared')">true</BuildChakraICUData>
 
-    <IcuLibraryDependencies Condition="'$(ChakraICU)'=='windows'">icuuc.lib;icuin.lib</IcuLibraryDependencies>
+    <IcuLibraryDependencies Condition="'$(ChakraICU)'=='windows'">icu.lib</IcuLibraryDependencies>
   </PropertyGroup>
 </Project>

--- a/Build/Chakra.Build.Default.props
+++ b/Build/Chakra.Build.Default.props
@@ -32,7 +32,17 @@
     <ChakraICU Condition="'$(ChakraICU)'==''">windows</ChakraICU>
 
     <BuildChakraICUData Condition="'$(BuildChakraICUData)'=='' AND ('$(ChakraICU)'=='static' OR '$(ChakraICU)'=='shared')">true</BuildChakraICUData>
-
-    <IcuLibraryDependencies Condition="'$(ChakraICU)'=='windows'">icu.lib</IcuLibraryDependencies>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(ChakraICU)' == 'windows' ">
+    <_UseModernWindowsIcu Condition=" Exists('$(SYSTEMROOT)\System32\icu.dll') ">true</_UseModernWindowsIcu>
+
+    <IcuLibraryDependencies Condition=" '$(_UseModernWindowsIcu)' == 'true' ">icu.lib</IcuLibraryDependencies>
+    <IcuLibraryDependencies Condition=" '$(_UseModernWindowsIcu)' != 'true' ">icuuc.lib;icuin.lib</IcuLibraryDependencies>
+  </PropertyGroup>
+
+  <Target Name="CheckIcuDependency" Condition=" '$(ChakraICU)' == 'windows' " BeforeTargets="Build">
+    <Warning Condition=" '$(_UseModernWindowsIcu)' != 'true' " Code="CCICU001" Text="You are compiling against an old version of libicu." />
+  </Target>
+
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ jobs:
       maxParallel: 4
       matrix:
         x86.Debug:
-          image_name: 'windows-2022'
+          image_name: 'windows-2025'
           build_type: 'debug'
           target: 'x86'
           special_build: ''
@@ -133,7 +133,7 @@ jobs:
           test_tags: ''
           build_outdir_suffix: ''
         x86.Test:
-          image_name: 'windows-2022'
+          image_name: 'windows-2025'
           build_type: 'test'
           target: 'x86'
           special_build: ''
@@ -141,7 +141,7 @@ jobs:
           test_tags: '--include-slow'
           build_outdir_suffix: ''
         x86.NoJit:
-          image_name: 'windows-2022'
+          image_name: 'windows-2025'
           build_type: 'debug'
           target: 'x86'
           special_build: '"/p:BuildJIT=false"'
@@ -149,7 +149,7 @@ jobs:
           test_tags: '-disablejit'
           build_outdir_suffix: '.NoJIT'
         x86.Release:
-          image_name: 'windows-2022'
+          image_name: 'windows-2025'
           build_type: 'release'
           target: 'x86'
           special_build: ''
@@ -157,7 +157,7 @@ jobs:
           test_tags: ''
           build_outdir_suffix: ''
         x64.Debug:
-          image_name: 'windows-2022'
+          image_name: 'windows-2025'
           build_type: 'debug'
           target: 'x64'
           special_build: ''
@@ -165,7 +165,7 @@ jobs:
           test_tags: ''
           build_outdir_suffix: ''
         x64.Test:
-          image_name: 'windows-2022'
+          image_name: 'windows-2025'
           build_type: 'test'
           target: 'x64'
           special_build: ''
@@ -173,23 +173,23 @@ jobs:
           test_tags: '--include-slow'
           build_outdir_suffix: ''
         x64.Release:
-          image_name: 'windows-2022'
+          image_name: 'windows-2025'
           build_type: 'release'
           target: 'x64'
           special_build: ''
           do_test: false
           test_tags: ''
           build_outdir_suffix: ''
-        win19.x86.Release:
-          image_name: 'windows-2019'
+        win22.x86.Release:
+          image_name: 'windows-2022'
           build_type: 'release'
           target: 'x86'
           special_build: ''
           do_test: false
           test_tags: ''
           build_outdir_suffix: ''
-        win19.x64.Release:
-          image_name: 'windows-2019'
+        win22.x64.Release:
+          image_name: 'windows-2022'
           build_type: 'release'
           target: 'x64'
           special_build: ''

--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -2437,43 +2437,40 @@ DEFINE_ISXLOCALEAVAILABLE(PR, uloc)
             return JavascriptString::NewWithBuffer(formatted, formattedLen, scriptContext);
         }
 
-        if (PlatformAgnostic::ICUHelpers::LinkedIcuMajorVersion() >= 61)
+#if !defined(ICU_VERSION) || ICU_VERSION >= 61
+        UErrorCode status = U_ZERO_ERROR;
+        ScopedUFieldPositionIterator fpi(ufieldpositer_open(&status));
+
+        EnsureBuffer([&](UChar *buf, int bufLen, UErrorCode *status)
         {
-            UErrorCode status = U_ZERO_ERROR;
-            ScopedUFieldPositionIterator fpi(ufieldpositer_open(&status));
+            return unum_formatDoubleForFields(*fmt, num, buf, bufLen, fpi, status);
+        }, scriptContext->GetRecycler(), &formatted, &formattedLen);
 
-            EnsureBuffer([&](UChar *buf, int bufLen, UErrorCode *status)
-            {
-                return unum_formatDoubleForFields(*fmt, num, buf, bufLen, fpi, status);
-            }, scriptContext->GetRecycler(), &formatted, &formattedLen);
+        NumberFormatPartsBuilder nfpb(num, formatted, formattedLen, scriptContext);
 
-            NumberFormatPartsBuilder nfpb(num, formatted, formattedLen, scriptContext);
-
-            int partStart = 0;
-            int partEnd = 0;
-            int i = 0;
-            for (int kind = ufieldpositer_next(fpi, &partStart, &partEnd); kind >= 0; kind = ufieldpositer_next(fpi, &partStart, &partEnd), ++i)
-            {
-                nfpb.InsertPart(static_cast<UNumberFormatFields>(kind), partStart, partEnd);
-            }
-
-            return nfpb.ToPartsArray();
-        }
-        else
+        int partStart = 0;
+        int partEnd = 0;
+        int i = 0;
+        for (int kind = ufieldpositer_next(fpi, &partStart, &partEnd); kind >= 0; kind = ufieldpositer_next(fpi, &partStart, &partEnd), ++i)
         {
-            JavascriptLibrary *library = scriptContext->GetLibrary();
-            JavascriptArray *ret = library->CreateArray(1);
-            DynamicObject *part = library->CreateObject();
-            EnsureBuffer([&](UChar *buf, int bufLen, UErrorCode *status)
-            {
-                return unum_formatDouble(*fmt, num, buf, bufLen, nullptr, status);
-            }, scriptContext->GetRecycler(), &formatted, &formattedLen);
-            JavascriptOperators::InitProperty(part, PropertyIds::type, library->GetIntlUnknownPartString());
-            JavascriptOperators::InitProperty(part, PropertyIds::value, JavascriptString::NewWithBuffer(formatted, formattedLen, scriptContext));
-
-            ret->SetItem(0, part, PropertyOperationFlags::PropertyOperation_None);
-            return ret;
+            nfpb.InsertPart(static_cast<UNumberFormatFields>(kind), partStart, partEnd);
         }
+
+        return nfpb.ToPartsArray();
+#else
+        JavascriptLibrary *library = scriptContext->GetLibrary();
+        JavascriptArray *ret = library->CreateArray(1);
+        DynamicObject* part = library->CreateObject();
+        EnsureBuffer([&](UChar *buf, int bufLen, UErrorCode *status)
+        {
+            return unum_formatDouble(*fmt, num, buf, bufLen, nullptr, status);
+        }, scriptContext->GetRecycler(), &formatted, &formattedLen);
+        JavascriptOperators::InitProperty(part, PropertyIds::type, library->GetIntlUnknownPartString());
+        JavascriptOperators::InitProperty(part, PropertyIds::value, JavascriptString::NewWithBuffer(formatted, formattedLen, scriptContext));
+
+        ret->SetItem(0, part, PropertyOperationFlags::PropertyOperation_None);
+        return ret;
+#endif // #if ICU_VERSION >= 61 ... #else
 #else
         INTL_CHECK_ARGS(
             args.Info.Count == 3 &&
@@ -3015,24 +3012,21 @@ DEFINE_ISXLOCALEAVAILABLE(PR, uloc)
         // For ICU < 61, we can fake it by creating an array of ["other"], which
         // uplrules_getKeywords is guaranteed to return at minimum.
         // This array is only used in resolved options, so the majority of the functionality can remain (namely, select() still works)
-        if (PlatformAgnostic::ICUHelpers::LinkedIcuMajorVersion() >= 61)
-        {
-            DynamicObject *state = UnsafeVarTo<DynamicObject>(args[1]);
-            FinalizableUPluralRules *pr = GetOrCreateCachedUPluralRules(state, scriptContext);
+#if !defined(ICU_VERSION) || ICU_VERSION >= 61
+        DynamicObject *state = UnsafeVarTo<DynamicObject>(args[1]);
+        FinalizableUPluralRules *pr = GetOrCreateCachedUPluralRules(state, scriptContext);
 
-            UErrorCode status = U_ZERO_ERROR;
-            ScopedUEnumeration keywords(uplrules_getKeywords(*pr, &status));
-            ICU_ASSERT(status, true);
+        UErrorCode status = U_ZERO_ERROR;
+        ScopedUEnumeration keywords(uplrules_getKeywords(*pr, &status));
+        ICU_ASSERT(status, true);
 
-            ForEachUEnumeration16(keywords, [&](int index, const char16 *kw, charcount_t kwLength)
-            {
-                ret->SetItem(index, JavascriptString::NewCopyBuffer(kw, kwLength, scriptContext), PropertyOperation_None);
-            });
-        }
-        else
+        ForEachUEnumeration16(keywords, [&](int index, const char16 *kw, charcount_t kwLength)
         {
-            ret->SetItem(0, scriptContext->GetLibrary()->GetIntlPluralRulesOtherString(), PropertyOperation_None);
-        }
+            ret->SetItem(index, JavascriptString::NewCopyBuffer(kw, kwLength, scriptContext), PropertyOperation_None);
+        });
+#else
+        ret->SetItem(0, scriptContext->GetLibrary()->GetIntlPluralRulesOtherString(), PropertyOperation_None);
+#endif
 
         return ret;
 #else

--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -2437,6 +2437,7 @@ DEFINE_ISXLOCALEAVAILABLE(PR, uloc)
             return JavascriptString::NewWithBuffer(formatted, formattedLen, scriptContext);
         }
 
+        // windows-icu does not define `ICU_VERSION` but does support `unum_formatDoubleForFields` (ICU 61+) since Windows 10 1809 "Redstone 5" (`NTDDI_WIN10_RS5`).
 #if !defined(ICU_VERSION) || ICU_VERSION >= 61
         UErrorCode status = U_ZERO_ERROR;
         ScopedUFieldPositionIterator fpi(ufieldpositer_open(&status));
@@ -3012,6 +3013,8 @@ DEFINE_ISXLOCALEAVAILABLE(PR, uloc)
         // For ICU < 61, we can fake it by creating an array of ["other"], which
         // uplrules_getKeywords is guaranteed to return at minimum.
         // This array is only used in resolved options, so the majority of the functionality can remain (namely, select() still works)
+        // 
+        // windows-icu does not define `ICU_VERSION` but does support `uplrules_getKeywords` (ICU 61+) since Windows 10 1809 "Redstone 5" (`NTDDI_WIN10_RS5`).
 #if !defined(ICU_VERSION) || ICU_VERSION >= 61
         DynamicObject *state = UnsafeVarTo<DynamicObject>(args[1]);
         FinalizableUPluralRules *pr = GetOrCreateCachedUPluralRules(state, scriptContext);

--- a/lib/Runtime/PlatformAgnostic/ChakraICU.h
+++ b/lib/Runtime/PlatformAgnostic/ChakraICU.h
@@ -102,6 +102,17 @@ namespace PlatformAgnostic
             u_getVersion(version);
             return version[0];
         }
+
+        inline int LinkedIcuMajorVersion()
+        {
+#if ICU_VERSION
+            return ICU_VERSION;
+#elif U_ICU_VERSION_MAJOR_NUM
+            return U_ICU_VERSION_MAJOR_NUM;
+#else
+            return GetICUMajorVersion();
+#endif
+        }
     }
 }
 #endif // ifdef HAS_ICU

--- a/lib/Runtime/PlatformAgnostic/ChakraICU.h
+++ b/lib/Runtime/PlatformAgnostic/ChakraICU.h
@@ -102,17 +102,6 @@ namespace PlatformAgnostic
             u_getVersion(version);
             return version[0];
         }
-
-        inline int LinkedIcuMajorVersion()
-        {
-#if ICU_VERSION
-            return ICU_VERSION;
-#elif U_ICU_VERSION_MAJOR_NUM
-            return U_ICU_VERSION_MAJOR_NUM;
-#else
-            return GetICUMajorVersion();
-#endif
-        }
     }
 }
 #endif // ifdef HAS_ICU

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,8 +8,6 @@ endif ()
 
 if (NO_ICU)
     set(TEST_ICU --not-tag exclude_noicu)
-elseif (NOT EMBED_ICU)
-    set(TEST_ICU --not-tag exclude_icu62AndAboveTestFailures)
 endif()
 
 if (BuildJIT)

--- a/test/DebuggerCommon/ES6_intl_simple_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_intl_simple_attach.js.dbg.baseline
@@ -131,7 +131,7 @@
               "#__proto__": "Object {...}",
               "constructor": "function <large string>",
               "resolvedOptions": "function <large string>",
-              "compare": "function <large string>"
+              "compare": "Error <large string>"
             },
             "length": "number 0",
             "name": "string Collator",
@@ -281,7 +281,8 @@
               "#__proto__": "Object {...}",
               "constructor": "function <large string>",
               "resolvedOptions": "function <large string>",
-              "format": "function <large string>"
+              "format": "Error <large string>",
+              "formatToParts": "function <large string>"
             },
             "length": "number 0",
             "name": "string NumberFormat",
@@ -323,6 +324,23 @@
               "arguments": "Error <large string>"
             },
             "length": "number 1"
+          },
+          "formatToParts": {
+            "#__proto__": {
+              "#__proto__": "Object {...}",
+              "constructor": "function <large string>",
+              "length": "number 0",
+              "name": "string ",
+              "apply": "function <large string>",
+              "bind": "function <large string>",
+              "call": "function <large string>",
+              "toString": "function <large string>",
+              "Symbol.hasInstance": "function <large string>",
+              "caller": "Error <large string>",
+              "arguments": "Error <large string>"
+            },
+            "length": "number 1",
+            "name": "string formatToParts"
           }
         }
       }
@@ -430,17 +448,12 @@
             "prototype": {
               "#__proto__": "Object {...}",
               "constructor": "function <large string>",
-              "format": "function <large string>",
+              "format": "Error <large string>",
+              "formatToParts": "function <large string>",
               "resolvedOptions": "function <large string>"
             },
             "length": "number 0",
             "name": "string DateTimeFormat",
-            "__relevantExtensionKeys": {
-              "#__proto__": "Array []",
-              "length": "number 2",
-              "[0]": "string \"ca\"",
-              "[1]": "string \"nu\""
-            },
             "supportedLocalesOf": {
               "#__proto__": "function <large string>",
               "length": "number 1",
@@ -462,6 +475,23 @@
               "arguments": "Error <large string>"
             },
             "length": "number 1"
+          },
+          "formatToParts": {
+            "#__proto__": {
+              "#__proto__": "Object {...}",
+              "constructor": "function <large string>",
+              "length": "number 0",
+              "name": "string ",
+              "apply": "function <large string>",
+              "bind": "function <large string>",
+              "call": "function <large string>",
+              "toString": "function <large string>",
+              "Symbol.hasInstance": "function <large string>",
+              "caller": "Error <large string>",
+              "arguments": "Error <large string>"
+            },
+            "length": "number 1",
+            "name": "string formatToParts"
           },
           "resolvedOptions": {
             "#__proto__": {

--- a/test/DebuggerCommon/rlexe.xml
+++ b/test/DebuggerCommon/rlexe.xml
@@ -218,8 +218,7 @@
       <files>ES6_intl_simple_attach.js</files>
       <compile-flags>-dbgbaseline:ES6_intl_simple_attach.js.dbg.baseline -Intl</compile-flags>
       <baseline>ES6_intl_simple_attach.js.baseline</baseline>
-      <!-- This test is still require_winglob because it has winglob-specific output in the .dbg.baseline -->
-      <tags>Intl,require_winglob</tags>
+      <tags>Intl</tags>
     </default>
   </test>
   <test>

--- a/test/Intl/GetCanonicalLocales.js
+++ b/test/Intl/GetCanonicalLocales.js
@@ -90,9 +90,15 @@ var tests = [
             // V8 and CC-ICU also give the default value of "yes" to non-boolean keys (co), which also is incorrect.
             // Everyone (should) correctly re-order extension keys alphabetically
             // Microsoft/ChakraCore#4490 tracks the incorrect defaulting, Microsoft/ChakraCore#2964 tracks the overall investigation
-            equal("de-DE-u-co-kn", "de-DE-u-co-yes-kn-true", gcl("de-de-u-kn-co")[0]);
-            equal("de-DE-u-co-phonebk-kn", "de-DE-u-co-phonebk-kn-true", gcl("de-de-u-kn-co-phonebk")[0]);
-            equal("de-DE-u-co-phonebk-kn-yes", "de-DE-u-co-phonebk-kn-true", gcl("de-DE-u-kn-yes-co-phonebk")[0]);
+            if (WScript.Platform.ICU_VERSION < 62) {
+                assert.areEqual(["de-DE-u-co-yes-kn-true"], Intl.getCanonicalLocales("de-de-u-kn-co"))
+                assert.areEqual(["de-DE-u-co-phonebk-kn-true"], Intl.getCanonicalLocales("de-de-u-kn-co-phonebk"))
+                assert.areEqual(["de-DE-u-co-phonebk-kn-true"], Intl.getCanonicalLocales("de-DE-u-kn-yes-co-phonebk"))
+            } else {
+                assert.areEqual(["de-DE-u-co-kn"], Intl.getCanonicalLocales("de-de-u-kn-co"))
+                assert.areEqual(["de-DE-u-co-phonebk-kn"], Intl.getCanonicalLocales("de-de-u-kn-co-phonebk"))
+                assert.areEqual(["de-DE-u-co-phonebk-kn"], Intl.getCanonicalLocales("de-DE-u-kn-yes-co-phonebk"))
+            }
 
             // De-dupe after locales are canonicalized
             assert.areEqual(Intl.getCanonicalLocales(['en-us', 'en-us']), ['en-US'], "No duplicates, same input casing (casing was incorrect)");
@@ -100,8 +106,8 @@ var tests = [
             assert.areEqual(Intl.getCanonicalLocales(['en-us', 'en-US']), ['en-US'], "No duplicates, different input casing");
 
             assert.areEqual(
+                ["de-DE", "de-DE-u-co-phonebk-kn"],
                 Intl.getCanonicalLocales(["de-de", "de-DE-u-co-phonebk-kn-true", "de-DE-u-kn-true-co-phonebk"]),
-                ["de-DE", "de-DE-u-co-phonebk-kn-true"],
                 "No duplicates after re-ordering options"
             );
         }
@@ -122,8 +128,12 @@ var tests = [
             // TODO (doilij): Investigate what is correct/allowable here (Microsoft/ChakraCore#2964)
             equal("xx-zzz", "zzz", gcl("xx-zzz")[0]);
 
-            // See discussion of defaulting above (V8/CC-ICU and CC-WinGlob/SM distinction remains true here)
-            equal("xx-ZZ-u-yy-zz", "xx-ZZ-u-yy-yes-zz-yes", gcl("xx-zz-u-zz-yy")[0]);
+            // See discussion of defaulting above
+            if (WScript.Platform.ICU_VERSION < 62) {
+                assert.areEqual(["xx-ZZ-u-yy-yes-zz-yes"], Intl.getCanonicalLocales("xx-zz-u-zz-yy"));
+            } else {
+                assert.areEqual(["xx-ZZ-u-yy-zz"], Intl.getCanonicalLocales("xx-zz-u-zz-yy"));
+            }
         }
     },
     {

--- a/test/Intl/GetCanonicalLocales.js
+++ b/test/Intl/GetCanonicalLocales.js
@@ -1,5 +1,6 @@
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
+// Copyright (c) ChakraCore Project Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 

--- a/test/Intl/IntlReturnedValueTests.js.dbg.baseline
+++ b/test/Intl/IntlReturnedValueTests.js.dbg.baseline
@@ -21,14 +21,14 @@
     "this": "Object {...}",
     "functionCallsReturn": {
       "[get format returned]": "function <large string>",
-      "[Intl.DateTimeFormat.prototype.format returned]": "string ‎2‎/‎1‎/‎2000"
+      "[Intl.DateTimeFormat.prototype.format returned]": "string 2/1/2000"
     },
     "locals": {
       "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "undefined undefined",
       "numberFormat1": "undefined undefined",
       "formattedNumber1": "undefined undefined",
@@ -46,7 +46,7 @@
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "undefined undefined",
       "formattedNumber1": "undefined undefined",
@@ -64,7 +64,7 @@
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "undefined undefined",
       "formattedNumber1": "undefined undefined",
@@ -75,14 +75,14 @@
   {
     "this": "Object {...}",
     "functionCallsReturn": {
-      "[resolvedOptions returned]": "Object {...}"
+      "[Intl.DateTimeFormat.prototype.resolvedOptions returned]": "Object {...}"
     },
     "locals": {
       "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "undefined undefined",
       "formattedNumber1": "undefined undefined",
@@ -100,7 +100,7 @@
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "Object {...}",
       "formattedNumber1": "undefined undefined",
@@ -119,7 +119,7 @@
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "Object {...}",
       "formattedNumber1": "string 123.456",
@@ -137,7 +137,7 @@
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "Object {...}",
       "formattedNumber1": "string 123.456",
@@ -148,14 +148,14 @@
   {
     "this": "Object {...}",
     "functionCallsReturn": {
-      "[resolvedOptions returned]": "Object {...}"
+      "[Intl.NumberFormat.prototype.resolvedOptions returned]": "Object {...}"
     },
     "locals": {
       "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "Object {...}",
       "formattedNumber1": "string 123.456",
@@ -173,7 +173,7 @@
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "Object {...}",
       "formattedNumber1": "string 123.456",
@@ -192,7 +192,7 @@
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "Object {...}",
       "formattedNumber1": "string 123.456",
@@ -210,7 +210,7 @@
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "Object {...}",
       "formattedNumber1": "string 123.456",
@@ -221,14 +221,14 @@
   {
     "this": "Object {...}",
     "functionCallsReturn": {
-      "[resolvedOptions returned]": "Object {...}"
+      "[Intl.Collator.prototype.resolvedOptions returned]": "Object {...}"
     },
     "locals": {
       "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
-      "date2": "string ‎2‎/‎1‎/‎2000",
+      "date2": "string 2/1/2000",
       "stringDate1": "string <large string>",
       "numberFormat1": "Object {...}",
       "formattedNumber1": "string 123.456",

--- a/test/Intl/rlexe.xml
+++ b/test/Intl/rlexe.xml
@@ -37,7 +37,7 @@
     <default>
       <files>GetCanonicalLocales.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
-      <tags>Intl,exclude_icu62AndAboveTestFailures</tags>
+      <tags>Intl</tags>
     </default>
   </test>
   <test>

--- a/test/Intl/rlexe.xml
+++ b/test/Intl/rlexe.xml
@@ -23,7 +23,7 @@
   <test>
     <default>
       <files>NumberFormat.js</files>
-      <tags>Intl,exclude_drt,exclude_icu62AndAboveTestFailures</tags>
+      <tags>Intl,exclude_drt</tags>
     </default>
   </test>
   <test>

--- a/test/Intl/rlexe.xml
+++ b/test/Intl/rlexe.xml
@@ -84,7 +84,7 @@
     <default>
       <compile-flags> -Intl -debugLaunch -dbgbaseline:IntlReturnedValueTests.js.dbg.baseline</compile-flags>
       <files>IntlReturnedValueTests.js</files>
-      <tags>Intl,require_winglob</tags> <!-- require_winglob because the baseline contains embedded bi-di markers -->
+      <tags>Intl</tags>
     </default>
   </test>
   <test>

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -175,7 +175,6 @@ elif args.show_passes:
 # xplat: temp hard coded to exclude unsupported tests
 if sys.platform != 'win32':
     not_tags.add('exclude_xplat')
-    not_tags.add('require_winglob')
     not_tags.add('require_simd')
 else:
     not_tags.add('exclude_windows')


### PR DESCRIPTION
`windows-2019` actions are unsupported as of 30.06.2025.

This PR updates the ci-config to run on the supported versions of the windows runner:
- `windows-2022` → `windows-2025`
- `windows-2019` → `windows-2022`

## 💥 Breaking changes
- The default CC configuration on windows used the [WinGlob](https://learn.microsoft.com/en-us/uwp/api/windows.globalization) api.
  This config is broken on recent versions of Windows 11 as CC does not initialize WinRT using [RoInitialize](https://learn.microsoft.com/en-us/windows/win32/api/roapi/nf-roapi-roinitialize) to allow for some optimizations.
- CC now uses the version of libICU that is [shipped with Windows](https://learn.microsoft.com/en-us/windows/win32/intl/international-components-for-unicode--icu-) by default
  This removes compat of the default config with all windows versions < Version 1903 (May 2019 Update)
  Should be fine as Windows 10 is out-of-support anyway...

## 🧪 Tests
- Tests did assume `win32 => WinGlob`; that is obviously wrong now.
- Some baselines were WinGlob only => updated
- libICU did return incorrect values so two tests were disabled => fixed
  The "new" behavior is consistent with recent node.js and bun.js
  - #4490
  - #2964 

---

See https://github.com/actions/runner-images/issues/12045
Fixes #7045
Fixes #4490 